### PR TITLE
r/heroku_app: Protect against panic

### DIFF
--- a/heroku/resource_heroku_app.go
+++ b/heroku/resource_heroku_app.go
@@ -333,7 +333,12 @@ func resourceHerokuAppRead(d *schema.ResourceData, meta interface{}) error {
 	configVars := make(map[string]string)
 	care := make(map[string]struct{})
 	for _, v := range d.Get("config_vars").([]interface{}) {
-		for k := range v.(map[string]interface{}) {
+		// Protect against panic on type cast for a nil-length array or map
+		n, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for k := range n {
 			care[k] = struct{}{}
 		}
 	}
@@ -355,6 +360,7 @@ func resourceHerokuAppRead(d *schema.ResourceData, meta interface{}) error {
 			configVars[k] = v
 		}
 	}
+
 	var configVarsValue []map[string]string
 	if len(configVars) > 0 {
 		configVarsValue = []map[string]string{configVars}


### PR DESCRIPTION
Protects against a panic caused by a nil value specified for `config_vars`.

```
$ make testacc TEST=./heroku TESTARGS="-run=TestAccHerokuApp_EmptyConfigVars"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./heroku -v -run=TestAccHerokuApp_EmptyConfigVars -timeout 120m
=== RUN   TestAccHerokuApp_EmptyConfigVars
--- PASS: TestAccHerokuApp_EmptyConfigVars (3.25s)
PASS
ok      github.com/terraform-providers/terraform-provider-heroku/heroku 3.256s
```
Fixes: #2 + https://github.com/hashicorp/terraform/issues/15555

Directly mentioning https://github.com/hashicorp/terraform/issues/15555, here, as this mostly solves the use case discussed in that issue. #2 is also solved via this patch, as this will protect the provider from panicking. However, this should have been caught via the parser in Terraform core. 