### PR TITLE
Set app when reading a heroku_addon resource

### DIFF
--- a/heroku/import_heroku_addon_test.go
+++ b/heroku/import_heroku_addon_test.go
@@ -4,14 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	heroku "github.com/cyberdelia/heroku-go/v3"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccHerokuAddon_importBasic(t *testing.T) {
-	var addon heroku.AddOn
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -21,34 +18,18 @@ func TestAccHerokuAddon_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckHerokuAddonConfig_basic(appName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckHerokuAddonExists("heroku_addon.foobar", &addon),
-					testAccCheckHerokuAddonAttributes(&addon, "deployhooks:http"),
-					resource.TestCheckResourceAttr(
-						"heroku_addon.foobar", "config.0.url", "http://google.com"),
-					resource.TestCheckResourceAttr(
-						"heroku_addon.foobar", "app", appName),
-					resource.TestCheckResourceAttr(
-						"heroku_addon.foobar", "plan", "deployhooks:http"),
-				),
 			},
 			{
 				ResourceName:            "heroku_addon.foobar",
 				ImportState:             true,
-				ImportStateCheck:        testAccCheckHerokuAddonImportedAttributes,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"config_vars"},
+				ImportStateVerifyIgnore: []string{"config_vars", "config"},
+			},
+			{
+				Config:             testAccCheckHerokuAddonConfig_basic(appName),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})
-}
-
-func testAccCheckHerokuAddonImportedAttributes(state []*terraform.InstanceState) error {
-	for _, s := range state {
-		fmt.Printf("%+v\n", s)
-		if app, ok := s.Attributes["app"]; !ok || app == "" {
-			return fmt.Errorf("No Addon app is set")
-		}
-	}
-	return nil
 }

--- a/heroku/import_heroku_addon_test.go
+++ b/heroku/import_heroku_addon_test.go
@@ -1,0 +1,54 @@
+package heroku
+
+import (
+	"fmt"
+	"testing"
+
+	heroku "github.com/cyberdelia/heroku-go/v3"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccHerokuAddon_importBasic(t *testing.T) {
+	var addon heroku.AddOn
+	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHerokuAddonDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuAddonConfig_basic(appName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHerokuAddonExists("heroku_addon.foobar", &addon),
+					testAccCheckHerokuAddonAttributes(&addon, "deployhooks:http"),
+					resource.TestCheckResourceAttr(
+						"heroku_addon.foobar", "config.0.url", "http://google.com"),
+					resource.TestCheckResourceAttr(
+						"heroku_addon.foobar", "app", appName),
+					resource.TestCheckResourceAttr(
+						"heroku_addon.foobar", "plan", "deployhooks:http"),
+				),
+			},
+			{
+				ResourceName:            "heroku_addon.foobar",
+				ImportState:             true,
+				ImportStateCheck:        testAccCheckHerokuAddonImportedAttributes,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"config_vars"},
+			},
+		},
+	})
+}
+
+func testAccCheckHerokuAddonImportedAttributes(state []*terraform.InstanceState) error {
+	for _, s := range state {
+		fmt.Printf("%+v\n", s)
+		if app, ok := s.Attributes["app"]; !ok || app == "" {
+			return fmt.Errorf("No Addon app is set")
+		}
+	}
+	return nil
+}

--- a/heroku/resource_heroku_addon.go
+++ b/heroku/resource_heroku_addon.go
@@ -134,6 +134,7 @@ func resourceHerokuAddonRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("name", addon.Name)
+	d.Set("app", addon.App.Name)
 	d.Set("plan", plan)
 	d.Set("provider_id", addon.ProviderID)
 	if err := d.Set("config_vars", addon.ConfigVars); err != nil {


### PR DESCRIPTION
When importing a `heroku_addon` resource, the `app` on that resource is not currently imported. The end result is you get the next Plan suggesting a new resource is required.

This change _should_ cause import to also import the `app` field.

Note: I can't currently find a way to make the tests fail on lack of this behavior. There's a bit of debugging code in the tests at the moment as a result. I'd definitely like to produce a working test case for this that fails when an `app` is missing from an import, but for now I wanted to get something out there for review. Suggestions on how to write a better test case for this would be much appreciated.