### PR TITLE
Handle updating an app's stack

### DIFF
--- a/heroku/import_heroku_app_test.go
+++ b/heroku/import_heroku_app_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccHerokuApp_importBasic(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	appStack := "heroku-16"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -18,7 +19,7 @@ func TestAccHerokuApp_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuAppDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAppConfig_basic(appName),
+				Config: testAccCheckHerokuAppConfig_basic(appName, appStack),
 			},
 			{
 				ResourceName:            "heroku_app.foobar",

--- a/heroku/resource_heroku_app.go
+++ b/heroku/resource_heroku_app.go
@@ -48,7 +48,7 @@ func (a *application) Update() error {
 			a.App = &herokuApplication{}
 			a.App.Name = app.Name
 			a.App.Region = app.Region.Name
-			a.App.Stack = app.Stack.Name
+			a.App.Stack = app.BuildStack.Name
 			a.App.GitURL = app.GitURL
 			a.App.WebURL = app.WebURL
 		}
@@ -61,7 +61,7 @@ func (a *application) Update() error {
 			a.App = &herokuApplication{}
 			a.App.Name = app.Name
 			a.App.Region = app.Region.Name
-			a.App.Stack = app.Stack.Name
+			a.App.Stack = app.BuildStack.Name
 			a.App.GitURL = app.GitURL
 			a.App.WebURL = app.WebURL
 			if app.Space != nil {

--- a/heroku/resource_heroku_app_test.go
+++ b/heroku/resource_heroku_app_test.go
@@ -288,8 +288,8 @@ func testAccCheckHerokuAppAttributes(app *heroku.App, appName, stackName string)
 			return fmt.Errorf("Bad region: %s", app.Region.Name)
 		}
 
-		if app.Stack.Name != stackName {
-			return fmt.Errorf("Bad stack: %s", app.Stack.Name)
+		if app.BuildStack.Name != stackName {
+			return fmt.Errorf("Bad stack: %s", app.BuildStack.Name)
 		}
 
 		if app.Name != appName {
@@ -313,8 +313,8 @@ func testAccCheckHerokuAppAttributesUpdated(app *heroku.App, appName, stackName 
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*heroku.Service)
 
-		if app.Stack.Name != stackName {
-			return fmt.Errorf("Bad stack: %s", app.Stack.Name)
+		if app.BuildStack.Name != stackName {
+			return fmt.Errorf("Bad stack: %s", app.BuildStack.Name)
 		}
 
 		if app.Name != appName {
@@ -431,8 +431,8 @@ func testAccCheckHerokuAppAttributesOrg(app *heroku.OrganizationApp, appName, sp
 			return fmt.Errorf("Bad space: %s", appSpace)
 		}
 
-		if app.Stack.Name != "heroku-16" {
-			return fmt.Errorf("Bad stack: %s", app.Stack.Name)
+		if app.BuildStack.Name != "heroku-16" {
+			return fmt.Errorf("Bad stack: %s", app.BuildStack.Name)
 		}
 
 		if app.Name != appName {

--- a/heroku/resource_heroku_app_test.go
+++ b/heroku/resource_heroku_app_test.go
@@ -15,6 +15,7 @@ import (
 func TestAccHerokuApp_Basic(t *testing.T) {
 	var app heroku.App
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	appStack := "heroku-16"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -22,10 +23,10 @@ func TestAccHerokuApp_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuAppDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAppConfig_basic(appName),
+				Config: testAccCheckHerokuAppConfig_basic(appName, appStack),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAppExists("heroku_app.foobar", &app),
-					testAccCheckHerokuAppAttributes(&app, appName),
+					testAccCheckHerokuAppAttributes(&app, appName, "heroku-16"),
 					resource.TestCheckResourceAttr(
 						"heroku_app.foobar", "name", appName),
 					resource.TestCheckResourceAttr(
@@ -36,10 +37,12 @@ func TestAccHerokuApp_Basic(t *testing.T) {
 	})
 }
 
-func TestAccHerokuApp_NameChange(t *testing.T) {
+func TestAccHerokuApp_Change(t *testing.T) {
 	var app heroku.App
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 	appName2 := fmt.Sprintf("%s-v2", appName)
+	appStack := "cedar-14"
+	appStack2 := "heroku-16"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -47,23 +50,27 @@ func TestAccHerokuApp_NameChange(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuAppDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAppConfig_basic(appName),
+				Config: testAccCheckHerokuAppConfig_basic(appName, appStack),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAppExists("heroku_app.foobar", &app),
-					testAccCheckHerokuAppAttributes(&app, appName),
+					testAccCheckHerokuAppAttributes(&app, appName, appStack),
 					resource.TestCheckResourceAttr(
 						"heroku_app.foobar", "name", appName),
+					resource.TestCheckResourceAttr(
+						"heroku_app.foobar", "stack", appStack),
 					resource.TestCheckResourceAttr(
 						"heroku_app.foobar", "config_vars.0.FOO", "bar"),
 				),
 			},
 			{
-				Config: testAccCheckHerokuAppConfig_updated(appName2),
+				Config: testAccCheckHerokuAppConfig_updated(appName2, appStack2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAppExists("heroku_app.foobar", &app),
-					testAccCheckHerokuAppAttributesUpdated(&app, appName2),
+					testAccCheckHerokuAppAttributesUpdated(&app, appName2, appStack2),
 					resource.TestCheckResourceAttr(
 						"heroku_app.foobar", "name", appName2),
+					resource.TestCheckResourceAttr(
+						"heroku_app.foobar", "stack", appStack2),
 					resource.TestCheckResourceAttr(
 						"heroku_app.foobar", "config_vars.0.FOO", "bing"),
 					resource.TestCheckResourceAttr(
@@ -77,6 +84,7 @@ func TestAccHerokuApp_NameChange(t *testing.T) {
 func TestAccHerokuApp_NukeVars(t *testing.T) {
 	var app heroku.App
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	appStack := "heroku-16"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -84,10 +92,10 @@ func TestAccHerokuApp_NukeVars(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuAppDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAppConfig_basic(appName),
+				Config: testAccCheckHerokuAppConfig_basic(appName, appStack),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAppExists("heroku_app.foobar", &app),
-					testAccCheckHerokuAppAttributes(&app, appName),
+					testAccCheckHerokuAppAttributes(&app, appName, "heroku-16"),
 					resource.TestCheckResourceAttr(
 						"heroku_app.foobar", "name", appName),
 					resource.TestCheckResourceAttr(
@@ -272,7 +280,7 @@ func testAccCheckHerokuAppDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckHerokuAppAttributes(app *heroku.App, appName string) resource.TestCheckFunc {
+func testAccCheckHerokuAppAttributes(app *heroku.App, appName, stackName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*heroku.Service)
 
@@ -280,7 +288,7 @@ func testAccCheckHerokuAppAttributes(app *heroku.App, appName string) resource.T
 			return fmt.Errorf("Bad region: %s", app.Region.Name)
 		}
 
-		if app.Stack.Name != "heroku-16" {
+		if app.Stack.Name != stackName {
 			return fmt.Errorf("Bad stack: %s", app.Stack.Name)
 		}
 
@@ -301,9 +309,13 @@ func testAccCheckHerokuAppAttributes(app *heroku.App, appName string) resource.T
 	}
 }
 
-func testAccCheckHerokuAppAttributesUpdated(app *heroku.App, appName string) resource.TestCheckFunc {
+func testAccCheckHerokuAppAttributesUpdated(app *heroku.App, appName, stackName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*heroku.Service)
+
+		if app.Stack.Name != stackName {
+			return fmt.Errorf("Bad stack: %s", app.Stack.Name)
+		}
 
 		if app.Name != appName {
 			return fmt.Errorf("Bad name: %s", app.Name)
@@ -523,16 +535,17 @@ func testAccInstallUnconfiguredBuildpack(t *testing.T, appName string) func() {
 	}
 }
 
-func testAccCheckHerokuAppConfig_basic(appName string) string {
+func testAccCheckHerokuAppConfig_basic(appName, appStack string) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "foobar" {
   name   = "%s"
+	stack = "%s"
   region = "us"
 
   config_vars {
     FOO = "bar"
   }
-}`, appName)
+}`, appName, appStack)
 }
 
 func testAccCheckHerokuAppConfig_go(appName string) string {
@@ -558,17 +571,18 @@ resource "heroku_app" "foobar" {
 }`, appName)
 }
 
-func testAccCheckHerokuAppConfig_updated(appName string) string {
+func testAccCheckHerokuAppConfig_updated(appName, appStack string) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "foobar" {
   name   = "%s"
+	stack  = "%s"
   region = "us"
 
   config_vars {
     FOO = "bing"
     BAZ = "bar"
   }
-}`, appName)
+}`, appName, appStack)
 }
 
 func testAccCheckHerokuAppConfig_no_vars(appName string) string {

--- a/heroku/resource_heroku_space.go
+++ b/heroku/resource_heroku_space.go
@@ -48,7 +48,7 @@ func resourceHerokuSpaceCreate(d *schema.ResourceData, meta interface{}) error {
 
 	opts := heroku.SpaceCreateOpts{}
 	opts.Name = d.Get("name").(string)
-	opts.Organization = d.Get("organization").(string)
+	opts.Team = d.Get("organization").(string)
 
 	if v, ok := d.GetOk("region"); ok {
 		vs := v.(string)

--- a/vendor/github.com/cyberdelia/heroku-go/v3/heroku.go
+++ b/vendor/github.com/cyberdelia/heroku-go/v3/heroku.go
@@ -15,14 +15,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/google/go-querystring/query"
 	"io"
 	"net/http"
 	"reflect"
 	"runtime"
 	"strings"
 	"time"
-
-	"github.com/google/go-querystring/query"
 )
 
 const (
@@ -701,9 +700,278 @@ func (s *Service) AddOnServiceList(ctx context.Context, lr *ListRange) (AddOnSer
 	return addOnService, s.Get(ctx, &addOnService, fmt.Sprintf("/addon-services"), nil, lr)
 }
 
+// Represents the details of a webhook subscription
+type AddOnWebhook struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when the webhook was created
+	ID        string    `json:"id" url:"id,key"`                 // the webhook's unique identifier
+	Include   []string  `json:"include" url:"include,key"`       // the entities that the subscription provides notifications for
+	Level     string    `json:"level" url:"level,key"`           // if `notify`, Heroku makes a single, fire-and-forget delivery attempt.
+	// If `sync`, Heroku attempts multiple deliveries until the request is
+	// successful or a limit is reached
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the webhook was updated
+	URL       string    `json:"url" url:"url,key"`               // the URL where the webhook's notification requests are sent
+}
+type AddOnWebhookCreateOpts struct {
+	Authorization *string `json:"authorization,omitempty" url:"authorization,omitempty,key"` // a custom `Authorization` header that Heroku will include with all
+	// webhook notifications
+	Include []string `json:"include" url:"include,key"` // the entities that the subscription provides notifications for
+	Level   string   `json:"level" url:"level,key"`     // if `notify`, Heroku makes a single, fire-and-forget delivery attempt.
+	// If `sync`, Heroku attempts multiple deliveries until the request is
+	// successful or a limit is reached
+	Secret *string `json:"secret,omitempty" url:"secret,omitempty,key"` // a value that Heroku will use to sign all webhook notification
+	// requests (the signature is included in the request’s
+	// `Heroku-Webhook-Hmac-SHA256` header)
+	URL string `json:"url" url:"url,key"` // the URL where the webhook's notification requests are sent
+}
+type AddOnWebhookCreateResult struct {
+	Addon struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
+		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
+	} `json:"addon" url:"addon,key"` // identity of add-on. Only used for add-on partner webhooks.
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when the webhook was created
+	ID        string    `json:"id" url:"id,key"`                 // the webhook's unique identifier
+	Include   []string  `json:"include" url:"include,key"`       // the entities that the subscription provides notifications for
+	Level     string    `json:"level" url:"level,key"`           // if `notify`, Heroku makes a single, fire-and-forget delivery attempt.
+	// If `sync`, Heroku attempts multiple deliveries until the request is
+	// successful or a limit is reached
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the webhook was updated
+	URL       string    `json:"url" url:"url,key"`               // the URL where the webhook's notification requests are sent
+}
+
+// Create an add-on webhook subscription.  Can only be accessed by the
+// add-on partner providing this add-on.
+func (s *Service) AddOnWebhookCreate(ctx context.Context, addOnIdentity string, o AddOnWebhookCreateOpts) (*AddOnWebhookCreateResult, error) {
+	var addOnWebhook AddOnWebhookCreateResult
+	return &addOnWebhook, s.Post(ctx, &addOnWebhook, fmt.Sprintf("/addons/%v/webhooks", addOnIdentity), o)
+}
+
+type AddOnWebhookDeleteResult struct {
+	Addon struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
+		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
+	} `json:"addon" url:"addon,key"` // identity of add-on. Only used for add-on partner webhooks.
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when the webhook was created
+	ID        string    `json:"id" url:"id,key"`                 // the webhook's unique identifier
+	Include   []string  `json:"include" url:"include,key"`       // the entities that the subscription provides notifications for
+	Level     string    `json:"level" url:"level,key"`           // if `notify`, Heroku makes a single, fire-and-forget delivery attempt.
+	// If `sync`, Heroku attempts multiple deliveries until the request is
+	// successful or a limit is reached
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the webhook was updated
+	URL       string    `json:"url" url:"url,key"`               // the URL where the webhook's notification requests are sent
+}
+
+// Removes an add-on webhook subscription.  Can only be accessed by the
+// add-on partner providing this add-on.
+func (s *Service) AddOnWebhookDelete(ctx context.Context, addOnIdentity string, appWebhookIdentity string) (*AddOnWebhookDeleteResult, error) {
+	var addOnWebhook AddOnWebhookDeleteResult
+	return &addOnWebhook, s.Delete(ctx, &addOnWebhook, fmt.Sprintf("/addons/%v/webhooks/%v", addOnIdentity, appWebhookIdentity))
+}
+
+type AddOnWebhookInfoResult struct {
+	Addon struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
+		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
+	} `json:"addon" url:"addon,key"` // identity of add-on. Only used for add-on partner webhooks.
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when the webhook was created
+	ID        string    `json:"id" url:"id,key"`                 // the webhook's unique identifier
+	Include   []string  `json:"include" url:"include,key"`       // the entities that the subscription provides notifications for
+	Level     string    `json:"level" url:"level,key"`           // if `notify`, Heroku makes a single, fire-and-forget delivery attempt.
+	// If `sync`, Heroku attempts multiple deliveries until the request is
+	// successful or a limit is reached
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the webhook was updated
+	URL       string    `json:"url" url:"url,key"`               // the URL where the webhook's notification requests are sent
+}
+
+// Returns the info for an add-on webhook subscription.  Can only be
+// accessed by the add-on partner providing this add-on.
+func (s *Service) AddOnWebhookInfo(ctx context.Context, addOnIdentity string, appWebhookIdentity string) (*AddOnWebhookInfoResult, error) {
+	var addOnWebhook AddOnWebhookInfoResult
+	return &addOnWebhook, s.Get(ctx, &addOnWebhook, fmt.Sprintf("/addons/%v/webhooks/%v", addOnIdentity, appWebhookIdentity), nil, nil)
+}
+
+type AddOnWebhookListResult []struct {
+	Addon struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
+		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
+	} `json:"addon" url:"addon,key"` // identity of add-on. Only used for add-on partner webhooks.
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when the webhook was created
+	ID        string    `json:"id" url:"id,key"`                 // the webhook's unique identifier
+	Include   []string  `json:"include" url:"include,key"`       // the entities that the subscription provides notifications for
+	Level     string    `json:"level" url:"level,key"`           // if `notify`, Heroku makes a single, fire-and-forget delivery attempt.
+	// If `sync`, Heroku attempts multiple deliveries until the request is
+	// successful or a limit is reached
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the webhook was updated
+	URL       string    `json:"url" url:"url,key"`               // the URL where the webhook's notification requests are sent
+}
+
+// List all webhook subscriptions for a particular add-on.  Can only be
+// accessed by the add-on partner providing this add-on.
+func (s *Service) AddOnWebhookList(ctx context.Context, addOnIdentity string, lr *ListRange) (AddOnWebhookListResult, error) {
+	var addOnWebhook AddOnWebhookListResult
+	return addOnWebhook, s.Get(ctx, &addOnWebhook, fmt.Sprintf("/addons/%v/webhooks", addOnIdentity), nil, lr)
+}
+
+type AddOnWebhookUpdateOpts struct {
+	Authorization *string `json:"authorization,omitempty" url:"authorization,omitempty,key"` // a custom `Authorization` header that Heroku will include with all
+	// webhook notifications
+	Include *[]*string `json:"include,omitempty" url:"include,omitempty,key"` // the entities that the subscription provides notifications for
+	Level   *string    `json:"level,omitempty" url:"level,omitempty,key"`     // if `notify`, Heroku makes a single, fire-and-forget delivery attempt.
+	// If `sync`, Heroku attempts multiple deliveries until the request is
+	// successful or a limit is reached
+	Secret *string `json:"secret,omitempty" url:"secret,omitempty,key"` // a value that Heroku will use to sign all webhook notification
+	// requests (the signature is included in the request’s
+	// `Heroku-Webhook-Hmac-SHA256` header)
+	URL *string `json:"url,omitempty" url:"url,omitempty,key"` // the URL where the webhook's notification requests are sent
+}
+type AddOnWebhookUpdateResult struct {
+	Addon struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
+		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
+	} `json:"addon" url:"addon,key"` // identity of add-on. Only used for add-on partner webhooks.
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when the webhook was created
+	ID        string    `json:"id" url:"id,key"`                 // the webhook's unique identifier
+	Include   []string  `json:"include" url:"include,key"`       // the entities that the subscription provides notifications for
+	Level     string    `json:"level" url:"level,key"`           // if `notify`, Heroku makes a single, fire-and-forget delivery attempt.
+	// If `sync`, Heroku attempts multiple deliveries until the request is
+	// successful or a limit is reached
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the webhook was updated
+	URL       string    `json:"url" url:"url,key"`               // the URL where the webhook's notification requests are sent
+}
+
+// Updates the details of an add-on webhook subscription.  Can only be
+// accessed by the add-on partner providing this add-on.
+func (s *Service) AddOnWebhookUpdate(ctx context.Context, addOnIdentity string, appWebhookIdentity string, o AddOnWebhookUpdateOpts) (*AddOnWebhookUpdateResult, error) {
+	var addOnWebhook AddOnWebhookUpdateResult
+	return &addOnWebhook, s.Patch(ctx, &addOnWebhook, fmt.Sprintf("/addons/%v/webhooks/%v", addOnIdentity, appWebhookIdentity), o)
+}
+
+// Represents the delivery of a webhook notification, including its
+// current status.
+type AddOnWebhookDelivery struct{}
+type AddOnWebhookDeliveryInfoResult struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when the delivery was created
+	Event     struct {
+		ID      string `json:"id" url:"id,key"`           // the event's unique identifier
+		Include string `json:"include" url:"include,key"` // the type of entity that the event is related to
+	} `json:"event" url:"event,key"` // identity of event
+	ID          string `json:"id" url:"id,key"` // the delivery's unique identifier
+	LastAttempt *struct {
+		Code       *int      `json:"code" url:"code,key"`               // http response code received during attempt
+		CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when attempt was created
+		ErrorClass *string   `json:"error_class" url:"error_class,key"` // error class encountered during attempt
+		ID         string    `json:"id" url:"id,key"`                   // unique identifier of attempt
+		Status     string    `json:"status" url:"status,key"`           // status of an attempt
+		UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when attempt was updated
+	} `json:"last_attempt" url:"last_attempt,key"` // last attempt of a delivery
+	NextAttemptAt *time.Time `json:"next_attempt_at" url:"next_attempt_at,key"` // when delivery will be attempted again
+	NumAttempts   int        `json:"num_attempts" url:"num_attempts,key"`       // number of times a delivery has been attempted
+	Status        string     `json:"status" url:"status,key"`                   // the delivery's status
+	UpdatedAt     time.Time  `json:"updated_at" url:"updated_at,key"`           // when the delivery was last updated
+	Webhook       struct {
+		ID    string `json:"id" url:"id,key"`       // the webhook's unique identifier
+		Level string `json:"level" url:"level,key"` // if `notify`, Heroku makes a single, fire-and-forget delivery attempt.
+		// If `sync`, Heroku attempts multiple deliveries until the request is
+		// successful or a limit is reached
+	} `json:"webhook" url:"webhook,key"` // identity of webhook
+}
+
+// Returns the info for an existing delivery.  Can only be accessed by
+// the add-on partner providing this add-on.
+func (s *Service) AddOnWebhookDeliveryInfo(ctx context.Context, addOnIdentity string, appWebhookDeliveryIdentity string) (*AddOnWebhookDeliveryInfoResult, error) {
+	var addOnWebhookDelivery AddOnWebhookDeliveryInfoResult
+	return &addOnWebhookDelivery, s.Get(ctx, &addOnWebhookDelivery, fmt.Sprintf("/addons/%v/webhook-deliveries/%v", addOnIdentity, appWebhookDeliveryIdentity), nil, nil)
+}
+
+type AddOnWebhookDeliveryListResult []struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when the delivery was created
+	Event     struct {
+		ID      string `json:"id" url:"id,key"`           // the event's unique identifier
+		Include string `json:"include" url:"include,key"` // the type of entity that the event is related to
+	} `json:"event" url:"event,key"` // identity of event
+	ID          string `json:"id" url:"id,key"` // the delivery's unique identifier
+	LastAttempt *struct {
+		Code       *int      `json:"code" url:"code,key"`               // http response code received during attempt
+		CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when attempt was created
+		ErrorClass *string   `json:"error_class" url:"error_class,key"` // error class encountered during attempt
+		ID         string    `json:"id" url:"id,key"`                   // unique identifier of attempt
+		Status     string    `json:"status" url:"status,key"`           // status of an attempt
+		UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when attempt was updated
+	} `json:"last_attempt" url:"last_attempt,key"` // last attempt of a delivery
+	NextAttemptAt *time.Time `json:"next_attempt_at" url:"next_attempt_at,key"` // when delivery will be attempted again
+	NumAttempts   int        `json:"num_attempts" url:"num_attempts,key"`       // number of times a delivery has been attempted
+	Status        string     `json:"status" url:"status,key"`                   // the delivery's status
+	UpdatedAt     time.Time  `json:"updated_at" url:"updated_at,key"`           // when the delivery was last updated
+	Webhook       struct {
+		ID    string `json:"id" url:"id,key"`       // the webhook's unique identifier
+		Level string `json:"level" url:"level,key"` // if `notify`, Heroku makes a single, fire-and-forget delivery attempt.
+		// If `sync`, Heroku attempts multiple deliveries until the request is
+		// successful or a limit is reached
+	} `json:"webhook" url:"webhook,key"` // identity of webhook
+}
+
+// Lists existing deliveries for an add-on.  Can only be accessed by the
+// add-on partner providing this add-on.
+func (s *Service) AddOnWebhookDeliveryList(ctx context.Context, addOnIdentity string, lr *ListRange) (AddOnWebhookDeliveryListResult, error) {
+	var addOnWebhookDelivery AddOnWebhookDeliveryListResult
+	return addOnWebhookDelivery, s.Get(ctx, &addOnWebhookDelivery, fmt.Sprintf("/addons/%v/webhook-deliveries", addOnIdentity), nil, lr)
+}
+
+// Represents a webhook event that occurred.
+type AddOnWebhookEvent struct{}
+type AddOnWebhookEventInfoResult struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when event was created
+	ID        string    `json:"id" url:"id,key"`                 // the event's unique identifier
+	Include   string    `json:"include" url:"include,key"`       // the type of entity that the event is related to
+	Payload   struct {
+		Action string `json:"action" url:"action,key"` // the type of event that occurred
+		Actor  struct {
+			Email string `json:"email" url:"email,key"` // unique email address of account
+			ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+		} `json:"actor" url:"actor,key"` // user that caused event
+		Data         struct{} `json:"data" url:"data,key"`                   // the current details of the event
+		PreviousData struct{} `json:"previous_data" url:"previous_data,key"` // previous details of the event (if any)
+		Resource     string   `json:"resource" url:"resource,key"`           // the type of resource associated with the event
+		Version      string   `json:"version" url:"version,key"`             // the version of the details provided for the event
+	} `json:"payload" url:"payload,key"` // payload of event
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the event was last updated
+}
+
+// Returns the info for a specified webhook event.  Can only be accessed
+// by the add-on partner providing this add-on.
+func (s *Service) AddOnWebhookEventInfo(ctx context.Context, addOnIdentity string, appWebhookEventIdentity string) (*AddOnWebhookEventInfoResult, error) {
+	var addOnWebhookEvent AddOnWebhookEventInfoResult
+	return &addOnWebhookEvent, s.Get(ctx, &addOnWebhookEvent, fmt.Sprintf("/addons/%v/webhook-events/%v", addOnIdentity, appWebhookEventIdentity), nil, nil)
+}
+
+type AddOnWebhookEventListResult []struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when event was created
+	ID        string    `json:"id" url:"id,key"`                 // the event's unique identifier
+	Include   string    `json:"include" url:"include,key"`       // the type of entity that the event is related to
+	Payload   struct {
+		Action string `json:"action" url:"action,key"` // the type of event that occurred
+		Actor  struct {
+			Email string `json:"email" url:"email,key"` // unique email address of account
+			ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+		} `json:"actor" url:"actor,key"` // user that caused event
+		Data         struct{} `json:"data" url:"data,key"`                   // the current details of the event
+		PreviousData struct{} `json:"previous_data" url:"previous_data,key"` // previous details of the event (if any)
+		Resource     string   `json:"resource" url:"resource,key"`           // the type of resource associated with the event
+		Version      string   `json:"version" url:"version,key"`             // the version of the details provided for the event
+	} `json:"payload" url:"payload,key"` // payload of event
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the event was last updated
+}
+
+// Lists existing webhook events for an add-on.  Can only be accessed by
+// the add-on partner providing this add-on.
+func (s *Service) AddOnWebhookEventList(ctx context.Context, addOnIdentity string, lr *ListRange) (AddOnWebhookEventListResult, error) {
+	var addOnWebhookEvent AddOnWebhookEventListResult
+	return addOnWebhookEvent, s.Get(ctx, &addOnWebhookEvent, fmt.Sprintf("/addons/%v/webhook-events", addOnIdentity), nil, lr)
+}
+
 // An app represents the program that you would like to deploy and run
 // on Heroku.
 type App struct {
+	Acm        bool       `json:"acm" url:"acm,key"`                 // ACM status of this app
 	ArchivedAt *time.Time `json:"archived_at" url:"archived_at,key"` // when app was archived
 	BuildStack struct {
 		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
@@ -796,6 +1064,24 @@ type AppUpdateOpts struct {
 func (s *Service) AppUpdate(ctx context.Context, appIdentity string, o AppUpdateOpts) (*App, error) {
 	var app App
 	return &app, s.Patch(ctx, &app, fmt.Sprintf("/apps/%v", appIdentity), o)
+}
+
+// Enable ACM flag for an app
+func (s *Service) AppEnableACM(ctx context.Context, appIdentity string) (*App, error) {
+	var app App
+	return &app, s.Post(ctx, &app, fmt.Sprintf("/apps/%v/acm", appIdentity), nil)
+}
+
+// Disable ACM flag for an app
+func (s *Service) AppDisableACM(ctx context.Context, appIdentity string) (*App, error) {
+	var app App
+	return &app, s.Delete(ctx, &app, fmt.Sprintf("/apps/%v/acm", appIdentity))
+}
+
+// Refresh ACM for an app
+func (s *Service) AppRefreshACM(ctx context.Context, appIdentity string) (*App, error) {
+	var app App
+	return &app, s.Patch(ctx, &app, fmt.Sprintf("/apps/%v/acm", appIdentity), nil)
 }
 
 // An app feature represents a Heroku labs capability that can be
@@ -979,6 +1265,213 @@ func (s *Service) AppTransferUpdate(ctx context.Context, appTransferIdentity str
 	return &appTransfer, s.Patch(ctx, &appTransfer, fmt.Sprintf("/account/app-transfers/%v", appTransferIdentity), o)
 }
 
+// Represents the details of a webhook subscription
+type AppWebhook struct{}
+type AppWebhookCreateOpts struct {
+	Authorization *string `json:"authorization,omitempty" url:"authorization,omitempty,key"` // a custom `Authorization` header that Heroku will include with all
+	// webhook notifications
+	Include []string `json:"include" url:"include,key"` // the entities that the subscription provides notifications for
+	Level   string   `json:"level" url:"level,key"`     // if `notify`, Heroku makes a single, fire-and-forget delivery attempt.
+	// If `sync`, Heroku attempts multiple deliveries until the request is
+	// successful or a limit is reached
+	Secret *string `json:"secret,omitempty" url:"secret,omitempty,key"` // a value that Heroku will use to sign all webhook notification
+	// requests (the signature is included in the request’s
+	// `Heroku-Webhook-Hmac-SHA256` header)
+	URL string `json:"url" url:"url,key"` // the URL where the webhook's notification requests are sent
+}
+type AppWebhookCreateResult struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // identity of app. Only used for customer webhooks.
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when the webhook was created
+	ID        string    `json:"id" url:"id,key"`                 // the webhook's unique identifier
+	Include   []string  `json:"include" url:"include,key"`       // the entities that the subscription provides notifications for
+	Level     string    `json:"level" url:"level,key"`           // if `notify`, Heroku makes a single, fire-and-forget delivery attempt.
+	// If `sync`, Heroku attempts multiple deliveries until the request is
+	// successful or a limit is reached
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the webhook was updated
+	URL       string    `json:"url" url:"url,key"`               // the URL where the webhook's notification requests are sent
+}
+
+// Create an app webhook subscription.
+func (s *Service) AppWebhookCreate(ctx context.Context, appIdentity string, o AppWebhookCreateOpts) (*AppWebhookCreateResult, error) {
+	var appWebhook AppWebhookCreateResult
+	return &appWebhook, s.Post(ctx, &appWebhook, fmt.Sprintf("/apps/%v/webhooks", appIdentity), o)
+}
+
+type AppWebhookDeleteResult struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // identity of app. Only used for customer webhooks.
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when the webhook was created
+	ID        string    `json:"id" url:"id,key"`                 // the webhook's unique identifier
+	Include   []string  `json:"include" url:"include,key"`       // the entities that the subscription provides notifications for
+	Level     string    `json:"level" url:"level,key"`           // if `notify`, Heroku makes a single, fire-and-forget delivery attempt.
+	// If `sync`, Heroku attempts multiple deliveries until the request is
+	// successful or a limit is reached
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the webhook was updated
+	URL       string    `json:"url" url:"url,key"`               // the URL where the webhook's notification requests are sent
+}
+
+// Removes an app webhook subscription.
+func (s *Service) AppWebhookDelete(ctx context.Context, appIdentity string, appWebhookIdentity string) (*AppWebhookDeleteResult, error) {
+	var appWebhook AppWebhookDeleteResult
+	return &appWebhook, s.Delete(ctx, &appWebhook, fmt.Sprintf("/apps/%v/webhooks/%v", appIdentity, appWebhookIdentity))
+}
+
+type AppWebhookInfoResult struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // identity of app. Only used for customer webhooks.
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when the webhook was created
+	ID        string    `json:"id" url:"id,key"`                 // the webhook's unique identifier
+	Include   []string  `json:"include" url:"include,key"`       // the entities that the subscription provides notifications for
+	Level     string    `json:"level" url:"level,key"`           // if `notify`, Heroku makes a single, fire-and-forget delivery attempt.
+	// If `sync`, Heroku attempts multiple deliveries until the request is
+	// successful or a limit is reached
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the webhook was updated
+	URL       string    `json:"url" url:"url,key"`               // the URL where the webhook's notification requests are sent
+}
+
+// Returns the info for an app webhook subscription.
+func (s *Service) AppWebhookInfo(ctx context.Context, appIdentity string, appWebhookIdentity string) (*AppWebhookInfoResult, error) {
+	var appWebhook AppWebhookInfoResult
+	return &appWebhook, s.Get(ctx, &appWebhook, fmt.Sprintf("/apps/%v/webhooks/%v", appIdentity, appWebhookIdentity), nil, nil)
+}
+
+type AppWebhookListResult []struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // identity of app. Only used for customer webhooks.
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when the webhook was created
+	ID        string    `json:"id" url:"id,key"`                 // the webhook's unique identifier
+	Include   []string  `json:"include" url:"include,key"`       // the entities that the subscription provides notifications for
+	Level     string    `json:"level" url:"level,key"`           // if `notify`, Heroku makes a single, fire-and-forget delivery attempt.
+	// If `sync`, Heroku attempts multiple deliveries until the request is
+	// successful or a limit is reached
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the webhook was updated
+	URL       string    `json:"url" url:"url,key"`               // the URL where the webhook's notification requests are sent
+}
+
+// List all webhook subscriptions for a particular app.
+func (s *Service) AppWebhookList(ctx context.Context, appIdentity string, lr *ListRange) (AppWebhookListResult, error) {
+	var appWebhook AppWebhookListResult
+	return appWebhook, s.Get(ctx, &appWebhook, fmt.Sprintf("/apps/%v/webhooks", appIdentity), nil, lr)
+}
+
+type AppWebhookUpdateOpts struct {
+	Authorization *string `json:"authorization,omitempty" url:"authorization,omitempty,key"` // a custom `Authorization` header that Heroku will include with all
+	// webhook notifications
+	Include *[]*string `json:"include,omitempty" url:"include,omitempty,key"` // the entities that the subscription provides notifications for
+	Level   *string    `json:"level,omitempty" url:"level,omitempty,key"`     // if `notify`, Heroku makes a single, fire-and-forget delivery attempt.
+	// If `sync`, Heroku attempts multiple deliveries until the request is
+	// successful or a limit is reached
+	Secret *string `json:"secret,omitempty" url:"secret,omitempty,key"` // a value that Heroku will use to sign all webhook notification
+	// requests (the signature is included in the request’s
+	// `Heroku-Webhook-Hmac-SHA256` header)
+	URL *string `json:"url,omitempty" url:"url,omitempty,key"` // the URL where the webhook's notification requests are sent
+}
+type AppWebhookUpdateResult struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // identity of app. Only used for customer webhooks.
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when the webhook was created
+	ID        string    `json:"id" url:"id,key"`                 // the webhook's unique identifier
+	Include   []string  `json:"include" url:"include,key"`       // the entities that the subscription provides notifications for
+	Level     string    `json:"level" url:"level,key"`           // if `notify`, Heroku makes a single, fire-and-forget delivery attempt.
+	// If `sync`, Heroku attempts multiple deliveries until the request is
+	// successful or a limit is reached
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the webhook was updated
+	URL       string    `json:"url" url:"url,key"`               // the URL where the webhook's notification requests are sent
+}
+
+// Updates the details of an app webhook subscription.
+func (s *Service) AppWebhookUpdate(ctx context.Context, appIdentity string, appWebhookIdentity string, o AppWebhookUpdateOpts) (*AppWebhookUpdateResult, error) {
+	var appWebhook AppWebhookUpdateResult
+	return &appWebhook, s.Patch(ctx, &appWebhook, fmt.Sprintf("/apps/%v/webhooks/%v", appIdentity, appWebhookIdentity), o)
+}
+
+// Represents the delivery of a webhook notification, including its
+// current status.
+type AppWebhookDelivery struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when the delivery was created
+	Event     struct {
+		ID      string `json:"id" url:"id,key"`           // the event's unique identifier
+		Include string `json:"include" url:"include,key"` // the type of entity that the event is related to
+	} `json:"event" url:"event,key"` // identity of event
+	ID          string `json:"id" url:"id,key"` // the delivery's unique identifier
+	LastAttempt *struct {
+		Code       *int      `json:"code" url:"code,key"`               // http response code received during attempt
+		CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when attempt was created
+		ErrorClass *string   `json:"error_class" url:"error_class,key"` // error class encountered during attempt
+		ID         string    `json:"id" url:"id,key"`                   // unique identifier of attempt
+		Status     string    `json:"status" url:"status,key"`           // status of an attempt
+		UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when attempt was updated
+	} `json:"last_attempt" url:"last_attempt,key"` // last attempt of a delivery
+	NextAttemptAt *time.Time `json:"next_attempt_at" url:"next_attempt_at,key"` // when delivery will be attempted again
+	NumAttempts   int        `json:"num_attempts" url:"num_attempts,key"`       // number of times a delivery has been attempted
+	Status        string     `json:"status" url:"status,key"`                   // the delivery's status
+	UpdatedAt     time.Time  `json:"updated_at" url:"updated_at,key"`           // when the delivery was last updated
+	Webhook       struct {
+		ID    string `json:"id" url:"id,key"`       // the webhook's unique identifier
+		Level string `json:"level" url:"level,key"` // if `notify`, Heroku makes a single, fire-and-forget delivery attempt.
+		// If `sync`, Heroku attempts multiple deliveries until the request is
+		// successful or a limit is reached
+	} `json:"webhook" url:"webhook,key"` // identity of webhook
+}
+
+// Returns the info for an existing delivery.
+func (s *Service) AppWebhookDeliveryInfo(ctx context.Context, appIdentity string, appWebhookDeliveryIdentity string) (*AppWebhookDelivery, error) {
+	var appWebhookDelivery AppWebhookDelivery
+	return &appWebhookDelivery, s.Get(ctx, &appWebhookDelivery, fmt.Sprintf("/apps/%v/webhook-deliveries/%v", appIdentity, appWebhookDeliveryIdentity), nil, nil)
+}
+
+type AppWebhookDeliveryListResult []AppWebhookDelivery
+
+// Lists existing deliveries for an app.
+func (s *Service) AppWebhookDeliveryList(ctx context.Context, appIdentity string, lr *ListRange) (AppWebhookDeliveryListResult, error) {
+	var appWebhookDelivery AppWebhookDeliveryListResult
+	return appWebhookDelivery, s.Get(ctx, &appWebhookDelivery, fmt.Sprintf("/apps/%v/webhook-deliveries", appIdentity), nil, lr)
+}
+
+// Represents a webhook event that occurred.
+type AppWebhookEvent struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when event was created
+	ID        string    `json:"id" url:"id,key"`                 // the event's unique identifier
+	Include   string    `json:"include" url:"include,key"`       // the type of entity that the event is related to
+	Payload   struct {
+		Action string `json:"action" url:"action,key"` // the type of event that occurred
+		Actor  struct {
+			Email string `json:"email" url:"email,key"` // unique email address of account
+			ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+		} `json:"actor" url:"actor,key"` // user that caused event
+		Data         struct{} `json:"data" url:"data,key"`                   // the current details of the event
+		PreviousData struct{} `json:"previous_data" url:"previous_data,key"` // previous details of the event (if any)
+		Resource     string   `json:"resource" url:"resource,key"`           // the type of resource associated with the event
+		Version      string   `json:"version" url:"version,key"`             // the version of the details provided for the event
+	} `json:"payload" url:"payload,key"` // payload of event
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the event was last updated
+}
+
+// Returns the info for a specified webhook event.
+func (s *Service) AppWebhookEventInfo(ctx context.Context, appIdentity string, appWebhookEventIdentity string) (*AppWebhookEvent, error) {
+	var appWebhookEvent AppWebhookEvent
+	return &appWebhookEvent, s.Get(ctx, &appWebhookEvent, fmt.Sprintf("/apps/%v/webhook-events/%v", appIdentity, appWebhookEventIdentity), nil, nil)
+}
+
+type AppWebhookEventListResult []AppWebhookEvent
+
+// Lists existing webhook events for an app.
+func (s *Service) AppWebhookEventList(ctx context.Context, appIdentity string, lr *ListRange) (AppWebhookEventListResult, error) {
+	var appWebhookEvent AppWebhookEventListResult
+	return appWebhookEvent, s.Get(ctx, &appWebhookEvent, fmt.Sprintf("/apps/%v/webhook-events", appIdentity), nil, lr)
+}
+
 // A build represents the process of transforming a code tarball into a
 // slug
 type Build struct {
@@ -1009,6 +1502,7 @@ type Build struct {
 		// downloaded.
 		Version *string `json:"version" url:"version,key"` // Version of the gzipped tarball.
 	} `json:"source_blob" url:"source_blob,key"` // location of gzipped tarball of source code used to create build
+	Stack     string    `json:"stack" url:"stack,key"`           // stack of build
 	Status    string    `json:"status" url:"status,key"`         // status of build
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when build was updated
 	User      struct {
@@ -1048,6 +1542,12 @@ type BuildListResult []Build
 func (s *Service) BuildList(ctx context.Context, appIdentity string, lr *ListRange) (BuildListResult, error) {
 	var build BuildListResult
 	return build, s.Get(ctx, &build, fmt.Sprintf("/apps/%v/builds", appIdentity), nil, lr)
+}
+
+// Destroy a build cache.
+func (s *Service) BuildDeleteCache(ctx context.Context, appIdentity string) (*Build, error) {
+	var build Build
+	return &build, s.Delete(ctx, &build, fmt.Sprintf("/apps/%v/build-cache", appIdentity))
 }
 
 // A build result contains the output from a build.
@@ -1226,7 +1726,9 @@ func (s *Service) CreditList(ctx context.Context, lr *ListRange) (CreditListResu
 
 // Domains define what web routes should be routed to an app on Heroku.
 type Domain struct {
-	App struct {
+	AcmStatus       *string `json:"acm_status" url:"acm_status,key"`               // status of this record's ACM
+	AcmStatusReason *string `json:"acm_status_reason" url:"acm_status_reason,key"` // reason for the status of this record's ACM
+	App             struct {
 		ID   string `json:"id" url:"id,key"`     // unique identifier of app
 		Name string `json:"name" url:"name,key"` // unique name of app
 	} `json:"app" url:"app,key"` // app that owns the domain
@@ -1376,7 +1878,8 @@ func (s *Service) DynoSizeList(ctx context.Context, lr *ListRange) (DynoSizeList
 	return dynoSize, s.Get(ctx, &dynoSize, fmt.Sprintf("/dyno-sizes"), nil, lr)
 }
 
-// An event represents an action performed on another API resource.
+// Deprecated: An event represents an action performed on another API
+// resource.
 type Event struct {
 	Action string `json:"action" url:"action,key"` // the operation performed on the resource
 	Actor  struct {
@@ -1420,8 +1923,8 @@ type Event struct {
 	Version      string     `json:"version" url:"version,key"`             // the event's API version string
 }
 
-// A failed event represents a failure of an action performed on another
-// API resource.
+// Deprecated: A failed event represents a failure of an action
+// performed on another API resource.
 type FailedEvent struct {
 	Action   string  `json:"action" url:"action,key"`     // The attempted operation performed on the resource.
 	Code     *int    `json:"code" url:"code,key"`         // An HTTP status code.
@@ -1449,15 +1952,19 @@ type FilterAppsAppsOpts struct {
 	} `json:"in,omitempty" url:"in,omitempty,key"`
 }
 type FilterAppsAppsResult []struct {
-	ArchivedAt                   *time.Time `json:"archived_at" url:"archived_at,key"`                                       // when app was archived
-	BuildpackProvidedDescription *string    `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
-	CreatedAt                    time.Time  `json:"created_at" url:"created_at,key"`                                         // when app was created
-	GitURL                       string     `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
-	ID                           string     `json:"id" url:"id,key"`                                                         // unique identifier of app
-	Joined                       bool       `json:"joined" url:"joined,key"`                                                 // is the current member a collaborator on this app.
-	Locked                       bool       `json:"locked" url:"locked,key"`                                                 // are other team members forbidden from joining this app.
-	Maintenance                  bool       `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
-	Name                         string     `json:"name" url:"name,key"`                                                     // unique name of app
+	ArchivedAt *time.Time `json:"archived_at" url:"archived_at,key"` // when app was archived
+	BuildStack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"build_stack" url:"build_stack,key"` // identity of the stack that will be used for new builds
+	BuildpackProvidedDescription *string   `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
+	CreatedAt                    time.Time `json:"created_at" url:"created_at,key"`                                         // when app was created
+	GitURL                       string    `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
+	ID                           string    `json:"id" url:"id,key"`                                                         // unique identifier of app
+	Joined                       bool      `json:"joined" url:"joined,key"`                                                 // is the current member a collaborator on this app.
+	Locked                       bool      `json:"locked" url:"locked,key"`                                                 // are other team members forbidden from joining this app.
+	Maintenance                  bool      `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
+	Name                         string    `json:"name" url:"name,key"`                                                     // unique name of app
 	Owner                        *struct {
 		Email string `json:"email" url:"email,key"` // unique email address of account
 		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
@@ -1690,67 +2197,6 @@ func (s *Service) InboundRulesetCreate(ctx context.Context, spaceIdentity string
 	return &inboundRuleset, s.Put(ctx, &inboundRuleset, fmt.Sprintf("/spaces/%v/inbound-ruleset", spaceIdentity), o)
 }
 
-// An invitation represents an invite sent to a user to use the Heroku
-// platform.
-type Invitation struct {
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when invitation was created
-	User      struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"user" url:"user,key"`
-	VerificationRequired bool `json:"verification_required" url:"verification_required,key"` // if the invitation requires verification
-}
-
-// Info for invitation.
-func (s *Service) InvitationInfo(ctx context.Context, invitationIdentity string) (*Invitation, error) {
-	var invitation Invitation
-	return &invitation, s.Get(ctx, &invitation, fmt.Sprintf("/invitations/%v", invitationIdentity), nil, nil)
-}
-
-type InvitationCreateOpts struct {
-	Email string  `json:"email" url:"email,key"` // unique email address of account
-	Name  *string `json:"name" url:"name,key"`   // full name of the account owner
-}
-
-// Invite a user.
-func (s *Service) InvitationCreate(ctx context.Context, o InvitationCreateOpts) (*Invitation, error) {
-	var invitation Invitation
-	return &invitation, s.Post(ctx, &invitation, fmt.Sprintf("/invitations"), o)
-}
-
-type InvitationSendVerificationCodeOpts struct {
-	Method      *string `json:"method,omitempty" url:"method,omitempty,key"` // Transport used to send verification code
-	PhoneNumber string  `json:"phone_number" url:"phone_number,key"`         // Phone number to send verification code
-}
-
-// Send a verification code for an invitation via SMS/phone call.
-func (s *Service) InvitationSendVerificationCode(ctx context.Context, invitationIdentity string, o InvitationSendVerificationCodeOpts) (*Invitation, error) {
-	var invitation Invitation
-	return &invitation, s.Post(ctx, &invitation, fmt.Sprintf("/invitations/%v/actions/send-verification", invitationIdentity), o)
-}
-
-type InvitationVerifyOpts struct {
-	VerificationCode string `json:"verification_code" url:"verification_code,key"` // Value used to verify invitation
-}
-
-// Verify an invitation using a verification code.
-func (s *Service) InvitationVerify(ctx context.Context, invitationIdentity string, o InvitationVerifyOpts) (*Invitation, error) {
-	var invitation Invitation
-	return &invitation, s.Post(ctx, &invitation, fmt.Sprintf("/invitations/%v/actions/verify", invitationIdentity), o)
-}
-
-type InvitationFinalizeOpts struct {
-	Password             string `json:"password" url:"password,key"`                                         // current password on the account
-	PasswordConfirmation string `json:"password_confirmation" url:"password_confirmation,key"`               // current password on the account
-	ReceiveNewsletter    *bool  `json:"receive_newsletter,omitempty" url:"receive_newsletter,omitempty,key"` // whether this user should receive a newsletter or not
-}
-
-// Finalize Invitation and Create Account.
-func (s *Service) InvitationFinalize(ctx context.Context, invitationIdentity string, o InvitationFinalizeOpts) (*Invitation, error) {
-	var invitation Invitation
-	return &invitation, s.Patch(ctx, &invitation, fmt.Sprintf("/invitations/%v", invitationIdentity), o)
-}
-
 // An invoice is an itemized bill of goods for an account which includes
 // pricing and charges.
 type Invoice struct {
@@ -1882,6 +2328,14 @@ func (s *Service) LogDrainDelete(ctx context.Context, appIdentity string, logDra
 func (s *Service) LogDrainInfo(ctx context.Context, appIdentity string, logDrainQueryIdentity string) (*LogDrain, error) {
 	var logDrain LogDrain
 	return &logDrain, s.Get(ctx, &logDrain, fmt.Sprintf("/apps/%v/log-drains/%v", appIdentity, logDrainQueryIdentity), nil, nil)
+}
+
+type LogDrainListByAddOnResult []LogDrain
+
+// List existing log drains for an add-on.
+func (s *Service) LogDrainListByAddOn(ctx context.Context, addOnIdentity string, lr *ListRange) (LogDrainListByAddOnResult, error) {
+	var logDrain LogDrainListByAddOnResult
+	return logDrain, s.Get(ctx, &logDrain, fmt.Sprintf("/addons/%v/log-drains", addOnIdentity), nil, lr)
 }
 
 type LogDrainListResult []LogDrain
@@ -2223,15 +2677,19 @@ func (s *Service) OrganizationAddOnListForOrganization(ctx context.Context, orga
 // Deprecated: An organization app encapsulates the organization
 // specific functionality of Heroku apps.
 type OrganizationApp struct {
-	ArchivedAt                   *time.Time `json:"archived_at" url:"archived_at,key"`                                       // when app was archived
-	BuildpackProvidedDescription *string    `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
-	CreatedAt                    time.Time  `json:"created_at" url:"created_at,key"`                                         // when app was created
-	GitURL                       string     `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
-	ID                           string     `json:"id" url:"id,key"`                                                         // unique identifier of app
-	Joined                       bool       `json:"joined" url:"joined,key"`                                                 // is the current member a collaborator on this app.
-	Locked                       bool       `json:"locked" url:"locked,key"`                                                 // are other organization members forbidden from joining this app.
-	Maintenance                  bool       `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
-	Name                         string     `json:"name" url:"name,key"`                                                     // unique name of app
+	ArchivedAt *time.Time `json:"archived_at" url:"archived_at,key"` // when app was archived
+	BuildStack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"build_stack" url:"build_stack,key"` // identity of the stack that will be used for new builds
+	BuildpackProvidedDescription *string   `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
+	CreatedAt                    time.Time `json:"created_at" url:"created_at,key"`                                         // when app was created
+	GitURL                       string    `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
+	ID                           string    `json:"id" url:"id,key"`                                                         // unique identifier of app
+	Joined                       bool      `json:"joined" url:"joined,key"`                                                 // is the current member a collaborator on this app.
+	Locked                       bool      `json:"locked" url:"locked,key"`                                                 // are other organization members forbidden from joining this app.
+	Maintenance                  bool      `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
+	Name                         string    `json:"name" url:"name,key"`                                                     // unique name of app
 	Organization                 *struct {
 		Name string `json:"name" url:"name,key"` // unique name of organization
 	} `json:"organization" url:"organization,key"` // organization that owns this app
@@ -2274,15 +2732,6 @@ type OrganizationAppCreateOpts struct {
 func (s *Service) OrganizationAppCreate(ctx context.Context, o OrganizationAppCreateOpts) (*OrganizationApp, error) {
 	var organizationApp OrganizationApp
 	return &organizationApp, s.Post(ctx, &organizationApp, fmt.Sprintf("/organizations/apps"), o)
-}
-
-type OrganizationAppListResult []OrganizationApp
-
-// List apps in the default organization, or in personal account, if
-// default organization is not set.
-func (s *Service) OrganizationAppList(ctx context.Context, lr *ListRange) (OrganizationAppListResult, error) {
-	var organizationApp OrganizationAppListResult
-	return organizationApp, s.Get(ctx, &organizationApp, fmt.Sprintf("/organizations/apps"), nil, lr)
 }
 
 type OrganizationAppListForOrganizationResult []OrganizationApp
@@ -2623,15 +3072,19 @@ func (s *Service) OrganizationMemberList(ctx context.Context, organizationIdenti
 }
 
 type OrganizationMemberAppListResult []struct {
-	ArchivedAt                   *time.Time `json:"archived_at" url:"archived_at,key"`                                       // when app was archived
-	BuildpackProvidedDescription *string    `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
-	CreatedAt                    time.Time  `json:"created_at" url:"created_at,key"`                                         // when app was created
-	GitURL                       string     `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
-	ID                           string     `json:"id" url:"id,key"`                                                         // unique identifier of app
-	Joined                       bool       `json:"joined" url:"joined,key"`                                                 // is the current member a collaborator on this app.
-	Locked                       bool       `json:"locked" url:"locked,key"`                                                 // are other organization members forbidden from joining this app.
-	Maintenance                  bool       `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
-	Name                         string     `json:"name" url:"name,key"`                                                     // unique name of app
+	ArchivedAt *time.Time `json:"archived_at" url:"archived_at,key"` // when app was archived
+	BuildStack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"build_stack" url:"build_stack,key"` // identity of the stack that will be used for new builds
+	BuildpackProvidedDescription *string   `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
+	CreatedAt                    time.Time `json:"created_at" url:"created_at,key"`                                         // when app was created
+	GitURL                       string    `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
+	ID                           string    `json:"id" url:"id,key"`                                                         // unique identifier of app
+	Joined                       bool      `json:"joined" url:"joined,key"`                                                 // is the current member a collaborator on this app.
+	Locked                       bool      `json:"locked" url:"locked,key"`                                                 // are other organization members forbidden from joining this app.
+	Maintenance                  bool      `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
+	Name                         string    `json:"name" url:"name,key"`                                                     // unique name of app
 	Organization                 *struct {
 		Name string `json:"name" url:"name,key"` // unique name of organization
 	} `json:"organization" url:"organization,key"` // organization that owns this app
@@ -3054,11 +3507,16 @@ type Release struct {
 		ID   string `json:"id" url:"id,key"`     // unique identifier of app
 		Name string `json:"name" url:"name,key"` // unique name of app
 	} `json:"app" url:"app,key"` // app involved in the release
-	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when release was created
-	Current     bool      `json:"current" url:"current,key"`         // indicates this release as being the current one for the app
-	Description string    `json:"description" url:"description,key"` // description of changes in this release
-	ID          string    `json:"id" url:"id,key"`                   // unique identifier of release
-	Slug        *struct {
+	CreatedAt       time.Time `json:"created_at" url:"created_at,key"`               // when release was created
+	Current         bool      `json:"current" url:"current,key"`                     // indicates this release as being the current one for the app
+	Description     string    `json:"description" url:"description,key"`             // description of changes in this release
+	ID              string    `json:"id" url:"id,key"`                               // unique identifier of release
+	OutputStreamURL *string   `json:"output_stream_url" url:"output_stream_url,key"` // Release command output will be available from this URL as a stream.
+	// The stream is available as either `text/plain` or
+	// `text/event-stream`. Clients should be prepared to handle disconnects
+	// and can resume the stream by sending a `Range` header (for
+	// `text/plain`) or a `Last-Event-Id` header (for `text/event-stream`).
+	Slug *struct {
 		ID string `json:"id" url:"id,key"` // unique identifier of slug
 	} `json:"slug" url:"slug,key"` // slug running in this release
 	Status    string    `json:"status" url:"status,key"`         // current status of the release
@@ -3305,10 +3763,10 @@ func (s *Service) SpaceDelete(ctx context.Context, spaceIdentity string) (*Space
 }
 
 type SpaceCreateOpts struct {
-	Name         string  `json:"name" url:"name,key"`                         // unique name of space
-	Organization string  `json:"organization" url:"organization,key"`         // unique name of organization
-	Region       *string `json:"region,omitempty" url:"region,omitempty,key"` // unique identifier of region
-	Shield       *bool   `json:"shield,omitempty" url:"shield,omitempty,key"` // true if this space has shield enabled
+	Name   string  `json:"name" url:"name,key"`                         // unique name of space
+	Region *string `json:"region,omitempty" url:"region,omitempty,key"` // unique identifier of region
+	Shield *bool   `json:"shield,omitempty" url:"shield,omitempty,key"` // true if this space has shield enabled
+	Team   string  `json:"team" url:"team,key"`                         // unique name of team
 }
 
 // Create a new space.
@@ -3538,15 +3996,19 @@ func (s *Service) TeamDelete(ctx context.Context, teamIdentity string) (*Team, e
 // An team app encapsulates the team specific functionality of Heroku
 // apps.
 type TeamApp struct {
-	ArchivedAt                   *time.Time `json:"archived_at" url:"archived_at,key"`                                       // when app was archived
-	BuildpackProvidedDescription *string    `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
-	CreatedAt                    time.Time  `json:"created_at" url:"created_at,key"`                                         // when app was created
-	GitURL                       string     `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
-	ID                           string     `json:"id" url:"id,key"`                                                         // unique identifier of app
-	Joined                       bool       `json:"joined" url:"joined,key"`                                                 // is the current member a collaborator on this app.
-	Locked                       bool       `json:"locked" url:"locked,key"`                                                 // are other team members forbidden from joining this app.
-	Maintenance                  bool       `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
-	Name                         string     `json:"name" url:"name,key"`                                                     // unique name of app
+	ArchivedAt *time.Time `json:"archived_at" url:"archived_at,key"` // when app was archived
+	BuildStack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"build_stack" url:"build_stack,key"` // identity of the stack that will be used for new builds
+	BuildpackProvidedDescription *string   `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
+	CreatedAt                    time.Time `json:"created_at" url:"created_at,key"`                                         // when app was created
+	GitURL                       string    `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
+	ID                           string    `json:"id" url:"id,key"`                                                         // unique identifier of app
+	Joined                       bool      `json:"joined" url:"joined,key"`                                                 // is the current member a collaborator on this app.
+	Locked                       bool      `json:"locked" url:"locked,key"`                                                 // are other team members forbidden from joining this app.
+	Maintenance                  bool      `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
+	Name                         string    `json:"name" url:"name,key"`                                                     // unique name of app
 	Owner                        *struct {
 		Email string `json:"email" url:"email,key"` // unique email address of account
 		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
@@ -3588,15 +4050,6 @@ type TeamAppCreateOpts struct {
 func (s *Service) TeamAppCreate(ctx context.Context, o TeamAppCreateOpts) (*TeamApp, error) {
 	var teamApp TeamApp
 	return &teamApp, s.Post(ctx, &teamApp, fmt.Sprintf("/teams/apps"), o)
-}
-
-type TeamAppListResult []TeamApp
-
-// List apps in the default team, or in personal account, if default
-// team is not set.
-func (s *Service) TeamAppList(ctx context.Context, lr *ListRange) (TeamAppListResult, error) {
-	var teamApp TeamAppListResult
-	return teamApp, s.Get(ctx, &teamApp, fmt.Sprintf("/teams/apps"), nil, lr)
 }
 
 // Info for a team app.
@@ -3924,15 +4377,19 @@ func (s *Service) TeamMemberList(ctx context.Context, teamIdentity string, lr *L
 }
 
 type TeamMemberListByMemberResult []struct {
-	ArchivedAt                   *time.Time `json:"archived_at" url:"archived_at,key"`                                       // when app was archived
-	BuildpackProvidedDescription *string    `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
-	CreatedAt                    time.Time  `json:"created_at" url:"created_at,key"`                                         // when app was created
-	GitURL                       string     `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
-	ID                           string     `json:"id" url:"id,key"`                                                         // unique identifier of app
-	Joined                       bool       `json:"joined" url:"joined,key"`                                                 // is the current member a collaborator on this app.
-	Locked                       bool       `json:"locked" url:"locked,key"`                                                 // are other team members forbidden from joining this app.
-	Maintenance                  bool       `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
-	Name                         string     `json:"name" url:"name,key"`                                                     // unique name of app
+	ArchivedAt *time.Time `json:"archived_at" url:"archived_at,key"` // when app was archived
+	BuildStack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"build_stack" url:"build_stack,key"` // identity of the stack that will be used for new builds
+	BuildpackProvidedDescription *string   `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
+	CreatedAt                    time.Time `json:"created_at" url:"created_at,key"`                                         // when app was created
+	GitURL                       string    `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
+	ID                           string    `json:"id" url:"id,key"`                                                         // unique identifier of app
+	Joined                       bool      `json:"joined" url:"joined,key"`                                                 // is the current member a collaborator on this app.
+	Locked                       bool      `json:"locked" url:"locked,key"`                                                 // are other team members forbidden from joining this app.
+	Maintenance                  bool      `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
+	Name                         string    `json:"name" url:"name,key"`                                                     // unique name of app
 	Owner                        *struct {
 		Email string `json:"email" url:"email,key"` // unique email address of account
 		ID    string `json:"id" url:"id,key"`       // unique identifier of an account

--- a/vendor/github.com/cyberdelia/heroku-go/v3/schema.json
+++ b/vendor/github.com/cyberdelia/heroku-go/v3/schema.json
@@ -1280,6 +1280,270 @@
         }
       }
     },
+    "add-on-webhook-delivery": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "Heroku Platform API - Add-on Webhook Delivery",
+      "description": "Represents the delivery of a webhook notification, including its current status.",
+      "stability": "production",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "links": [
+        {
+          "description": "Returns the info for an existing delivery.  Can only be accessed by the add-on partner providing this add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/webhook-deliveries/{(%23%2Fdefinitions%2Fapp-webhook-delivery%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/app-webhook-delivery"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Lists existing deliveries for an add-on.  Can only be accessed by the add-on partner providing this add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/webhook-deliveries",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/app-webhook-delivery"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ]
+    },
+    "add-on-webhook-event": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "Heroku Platform API - Add-on Webhook Event",
+      "description": "Represents a webhook event that occurred.",
+      "stability": "production",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "links": [
+        {
+          "description": "Returns the info for a specified webhook event.  Can only be accessed by the add-on partner providing this add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/webhook-events/{(%23%2Fdefinitions%2Fapp-webhook-event%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/app-webhook-event"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Lists existing webhook events for an add-on.  Can only be accessed by the add-on partner providing this add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/webhook-events",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/app-webhook-event"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ]
+    },
+    "add-on-webhook": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "Heroku Platform API - Add-on Webhook",
+      "description": "Represents the details of a webhook subscription",
+      "stability": "production",
+      "strictProperties": false,
+      "additionalProperties": false,
+      "required": [
+        "created_at",
+        "id",
+        "include",
+        "level",
+        "updated_at",
+        "url"
+      ],
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "addon_webhook": {
+          "properties": {
+            "addon": {
+              "description": "identity of add-on. Only used for add-on partner webhooks.",
+              "properties": {
+                "id": {
+                  "$ref": "#/definitions/add-on/definitions/id"
+                },
+                "name": {
+                  "$ref": "#/definitions/add-on/definitions/name"
+                }
+              },
+              "strictProperties": true,
+              "type": [
+                "object"
+              ]
+            },
+            "created_at": {
+              "$ref": "#/definitions/app-webhook/definitions/created_at"
+            },
+            "id": {
+              "$ref": "#/definitions/app-webhook/definitions/id"
+            },
+            "include": {
+              "$ref": "#/definitions/app-webhook/definitions/include"
+            },
+            "level": {
+              "$ref": "#/definitions/app-webhook/definitions/level"
+            },
+            "updated_at": {
+              "$ref": "#/definitions/app-webhook/definitions/updated_at"
+            },
+            "url": {
+              "$ref": "#/definitions/app-webhook/definitions/url"
+            }
+          },
+          "description": "add-on webhook",
+          "type": [
+            "object"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create an add-on webhook subscription.  Can only be accessed by the add-on partner providing this add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/webhooks",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "authorization": {
+                "$ref": "#/definitions/app-webhook/definitions/authorization"
+              },
+              "include": {
+                "$ref": "#/definitions/app-webhook/definitions/include"
+              },
+              "level": {
+                "$ref": "#/definitions/app-webhook/definitions/level"
+              },
+              "secret": {
+                "$ref": "#/definitions/app-webhook/definitions/secret"
+              },
+              "url": {
+                "$ref": "#/definitions/app-webhook/definitions/url"
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "include",
+              "level",
+              "url"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/add-on-webhook/definitions/addon_webhook"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Removes an add-on webhook subscription.  Can only be accessed by the add-on partner providing this add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/webhooks/{(%23%2Fdefinitions%2Fapp-webhook%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/add-on-webhook/definitions/addon_webhook"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Returns the info for an add-on webhook subscription.  Can only be accessed by the add-on partner providing this add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/webhooks/{(%23%2Fdefinitions%2Fapp-webhook%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/add-on-webhook/definitions/addon_webhook"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List all webhook subscriptions for a particular add-on.  Can only be accessed by the add-on partner providing this add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/webhooks",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on-webhook/definitions/addon_webhook"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Updates the details of an add-on webhook subscription.  Can only be accessed by the add-on partner providing this add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/webhooks/{(%23%2Fdefinitions%2Fapp-webhook%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "authorization": {
+                "$ref": "#/definitions/app-webhook/definitions/authorization"
+              },
+              "include": {
+                "$ref": "#/definitions/app-webhook/definitions/include"
+              },
+              "level": {
+                "$ref": "#/definitions/app-webhook/definitions/level"
+              },
+              "secret": {
+                "$ref": "#/definitions/app-webhook/definitions/secret"
+              },
+              "url": {
+                "$ref": "#/definitions/app-webhook/definitions/url"
+              }
+            },
+            "strictProperties": false,
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/add-on-webhook/definitions/addon_webhook"
+          },
+          "title": "Update"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/app-webhook/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/app-webhook/definitions/id"
+        },
+        "include": {
+          "$ref": "#/definitions/app-webhook/definitions/include"
+        },
+        "level": {
+          "$ref": "#/definitions/app-webhook/definitions/level"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/app-webhook/definitions/updated_at"
+        },
+        "url": {
+          "$ref": "#/definitions/app-webhook/definitions/url"
+        }
+      }
+    },
     "add-on": {
       "description": "Add-ons represent add-ons that have been provisioned and attached to one or more apps.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
@@ -2459,6 +2723,643 @@
         }
       }
     },
+    "app-webhook-delivery": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "Heroku Platform API - App Webhook Delivery",
+      "description": "Represents the delivery of a webhook notification, including its current status.",
+      "stability": "production",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "attempt_id": {
+          "description": "unique identifier of attempt",
+          "readOnly": true,
+          "format": "uuid",
+          "type": [
+            "string"
+          ]
+        },
+        "attempt_error_class": {
+          "description": "error class encountered during attempt",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "attempt_code": {
+          "description": "http response code received during attempt",
+          "readOnly": true,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "attempt_created_at": {
+          "description": "when attempt was created",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "attempt_updated_at": {
+          "description": "when attempt was updated",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "attempt_status": {
+          "description": "status of an attempt",
+          "enum": [
+            "scheduled",
+            "succeeded",
+            "failed"
+          ],
+          "example": "scheduled",
+          "type": [
+            "string"
+          ]
+        },
+        "created_at": {
+          "description": "when the delivery was created",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "the delivery's unique identifier",
+          "readOnly": true,
+          "format": "uuid",
+          "type": [
+            "string"
+          ]
+        },
+        "num_attempts": {
+          "description": "number of times a delivery has been attempted",
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/app-webhook-delivery/definitions/id"
+            }
+          ]
+        },
+        "next_attempt_at": {
+          "description": "when delivery will be attempted again",
+          "format": "date-time",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "status": {
+          "description": "the delivery's status",
+          "enum": [
+            "pending",
+            "scheduled",
+            "retrying",
+            "failed",
+            "succeeded"
+          ],
+          "example": "pending",
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when the delivery was last updated",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Returns the info for an existing delivery.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/webhook-deliveries/{(%23%2Fdefinitions%2Fapp-webhook-delivery%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/app-webhook-delivery"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Lists existing deliveries for an app.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/webhook-deliveries",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/app-webhook-delivery"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/app-webhook-delivery/definitions/created_at"
+        },
+        "event": {
+          "description": "identity of event",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/app-webhook-event/definitions/id"
+            },
+            "include": {
+              "$ref": "#/definitions/app-webhook-event/definitions/include"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "id": {
+          "$ref": "#/definitions/app-webhook-delivery/definitions/id"
+        },
+        "num_attempts": {
+          "$ref": "#/definitions/app-webhook-delivery/definitions/num_attempts"
+        },
+        "next_attempt_at": {
+          "$ref": "#/definitions/app-webhook-delivery/definitions/next_attempt_at"
+        },
+        "last_attempt": {
+          "description": "last attempt of a delivery",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/app-webhook-delivery/definitions/attempt_id"
+            },
+            "code": {
+              "$ref": "#/definitions/app-webhook-delivery/definitions/attempt_code"
+            },
+            "error_class": {
+              "$ref": "#/definitions/app-webhook-delivery/definitions/attempt_error_class"
+            },
+            "status": {
+              "$ref": "#/definitions/app-webhook-delivery/definitions/attempt_status"
+            },
+            "created_at": {
+              "$ref": "#/definitions/app-webhook-delivery/definitions/attempt_created_at"
+            },
+            "updated_at": {
+              "$ref": "#/definitions/app-webhook-delivery/definitions/attempt_updated_at"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "status": {
+          "$ref": "#/definitions/app-webhook-delivery/definitions/status"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/app-webhook-delivery/definitions/updated_at"
+        },
+        "webhook": {
+          "description": "identity of webhook",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/app-webhook/definitions/id"
+            },
+            "level": {
+              "$ref": "#/definitions/app-webhook/definitions/level"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "app-webhook-event": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "Heroku Platform API - App Webhook Event",
+      "description": "Represents a webhook event that occurred.",
+      "stability": "production",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "action": {
+          "description": "the type of event that occurred",
+          "example": "create",
+          "type": [
+            "string"
+          ]
+        },
+        "actor": {
+          "description": "user that caused event",
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "created_at": {
+          "description": "when event was created",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "data": {
+          "description": "the current details of the event",
+          "type": [
+            "object"
+          ]
+        },
+        "id": {
+          "description": "the event's unique identifier",
+          "readOnly": true,
+          "format": "uuid",
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/app-webhook-event/definitions/id"
+            }
+          ]
+        },
+        "include": {
+          "description": "the type of entity that the event is related to",
+          "example": "api:release",
+          "type": [
+            "string"
+          ]
+        },
+        "payload": {
+          "description": "payload of event",
+          "properties": {
+            "action": {
+              "$ref": "#/definitions/app-webhook-event/definitions/action"
+            },
+            "actor": {
+              "$ref": "#/definitions/app-webhook-event/definitions/actor"
+            },
+            "data": {
+              "$ref": "#/definitions/app-webhook-event/definitions/data"
+            },
+            "previous_data": {
+              "$ref": "#/definitions/app-webhook-event/definitions/previous_data"
+            },
+            "resource": {
+              "$ref": "#/definitions/app-webhook-event/definitions/resource"
+            },
+            "version": {
+              "$ref": "#/definitions/app-webhook-event/definitions/version"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "previous_data": {
+          "description": "previous details of the event (if any)",
+          "type": [
+            "object"
+          ]
+        },
+        "resource": {
+          "description": "the type of resource associated with the event",
+          "example": "release",
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when the event was last updated",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "version": {
+          "description": "the version of the details provided for the event",
+          "example": "1",
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Returns the info for a specified webhook event.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/webhook-events/{(%23%2Fdefinitions%2Fapp-webhook-event%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/app-webhook-event"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Lists existing webhook events for an app.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/webhook-events",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/app-webhook-event"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/app-webhook-event/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/app-webhook-event/definitions/id"
+        },
+        "include": {
+          "$ref": "#/definitions/app-webhook-event/definitions/include"
+        },
+        "payload": {
+          "$ref": "#/definitions/app-webhook-event/definitions/payload"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/app-webhook-event/definitions/updated_at"
+        }
+      }
+    },
+    "app-webhook": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "Heroku Platform API - App Webhook",
+      "description": "Represents the details of a webhook subscription",
+      "stability": "production",
+      "strictProperties": false,
+      "additionalProperties": false,
+      "required": [
+        "created_at",
+        "id",
+        "include",
+        "level",
+        "updated_at",
+        "url"
+      ],
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "authorization": {
+          "description": "a custom `Authorization` header that Heroku will include with all webhook notifications",
+          "example": "Bearer 9266671b2767f804c9d5809c2d384ed57d8f8ce1abd1043e1fb3fbbcb8c3",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "created_at": {
+          "description": "when the webhook was created",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "the webhook's unique identifier",
+          "readOnly": true,
+          "format": "uuid",
+          "type": [
+            "string"
+          ]
+        },
+        "include": {
+          "description": "the entities that the subscription provides notifications for",
+          "items": {
+            "example": "api:release",
+            "type": [
+              "string"
+            ]
+          },
+          "type": [
+            "array"
+          ]
+        },
+        "level": {
+          "description": "if `notify`, Heroku makes a single, fire-and-forget delivery attempt. If `sync`, Heroku attempts multiple deliveries until the request is successful or a limit is reached",
+          "enum": [
+            "notify",
+            "sync"
+          ],
+          "example": "notify",
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/app-webhook/definitions/id"
+            }
+          ]
+        },
+        "secret": {
+          "description": "a value that Heroku will use to sign all webhook notification requests (the signature is included in the request’s `Heroku-Webhook-Hmac-SHA256` header)",
+          "example": "dcbff0c4430a2960a2552389d587bc58d30a37a8cf3f75f8fb77abe667ad",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when the webhook was updated",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "url": {
+          "description": "the URL where the webhook's notification requests are sent",
+          "format": "uri",
+          "type": [
+            "string"
+          ]
+        },
+        "app_webhook": {
+          "properties": {
+            "app": {
+              "description": "identity of app. Only used for customer webhooks.",
+              "properties": {
+                "id": {
+                  "$ref": "#/definitions/app/definitions/id"
+                },
+                "name": {
+                  "$ref": "#/definitions/app/definitions/name"
+                }
+              },
+              "strictProperties": true,
+              "type": [
+                "object"
+              ]
+            },
+            "created_at": {
+              "$ref": "#/definitions/app-webhook/definitions/created_at"
+            },
+            "id": {
+              "$ref": "#/definitions/app-webhook/definitions/id"
+            },
+            "include": {
+              "$ref": "#/definitions/app-webhook/definitions/include"
+            },
+            "level": {
+              "$ref": "#/definitions/app-webhook/definitions/level"
+            },
+            "updated_at": {
+              "$ref": "#/definitions/app-webhook/definitions/updated_at"
+            },
+            "url": {
+              "$ref": "#/definitions/app-webhook/definitions/url"
+            }
+          },
+          "description": "app webhook",
+          "type": [
+            "object"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create an app webhook subscription.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/webhooks",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "authorization": {
+                "$ref": "#/definitions/app-webhook/definitions/authorization"
+              },
+              "include": {
+                "$ref": "#/definitions/app-webhook/definitions/include"
+              },
+              "level": {
+                "$ref": "#/definitions/app-webhook/definitions/level"
+              },
+              "secret": {
+                "$ref": "#/definitions/app-webhook/definitions/secret"
+              },
+              "url": {
+                "$ref": "#/definitions/app-webhook/definitions/url"
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "include",
+              "level",
+              "url"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/app-webhook/definitions/app_webhook"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Removes an app webhook subscription.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/webhooks/{(%23%2Fdefinitions%2Fapp-webhook%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/app-webhook/definitions/app_webhook"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Returns the info for an app webhook subscription.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/webhooks/{(%23%2Fdefinitions%2Fapp-webhook%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/app-webhook/definitions/app_webhook"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List all webhook subscriptions for a particular app.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/webhooks",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/app-webhook/definitions/app_webhook"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Updates the details of an app webhook subscription.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/webhooks/{(%23%2Fdefinitions%2Fapp-webhook%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "authorization": {
+                "$ref": "#/definitions/app-webhook/definitions/authorization"
+              },
+              "include": {
+                "$ref": "#/definitions/app-webhook/definitions/include"
+              },
+              "level": {
+                "$ref": "#/definitions/app-webhook/definitions/level"
+              },
+              "secret": {
+                "$ref": "#/definitions/app-webhook/definitions/secret"
+              },
+              "url": {
+                "$ref": "#/definitions/app-webhook/definitions/url"
+              }
+            },
+            "strictProperties": false,
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/app-webhook/definitions/app_webhook"
+          },
+          "title": "Update"
+        }
+      ]
+    },
     "app": {
       "description": "An app represents the program that you would like to deploy and run on Heroku.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
@@ -2715,9 +3616,42 @@
             "$ref": "#/definitions/app"
           },
           "title": "Update"
+        },
+        {
+          "description": "Enable ACM flag for an app",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/acm",
+          "method": "POST",
+          "rel": "update",
+          "targetSchema": {
+            "$ref": "#/definitions/app"
+          },
+          "title": "Enable ACM"
+        },
+        {
+          "description": "Disable ACM flag for an app",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/acm",
+          "method": "DELETE",
+          "rel": "delete",
+          "targetSchema": {
+            "$ref": "#/definitions/app"
+          },
+          "title": "Disable ACM"
+        },
+        {
+          "description": "Refresh ACM for an app",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/acm",
+          "method": "PATCH",
+          "rel": "update",
+          "targetSchema": {
+            "$ref": "#/definitions/app"
+          },
+          "title": "Refresh ACM"
         }
       ],
       "properties": {
+        "acm": {
+          "$ref": "#/definitions/app/definitions/acm"
+        },
         "archived_at": {
           "$ref": "#/definitions/app/definitions/archived_at"
         },
@@ -3100,6 +4034,14 @@
             "object"
           ]
         },
+        "stack": {
+          "description": "stack of build",
+          "example": "heroku-16",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
         "status": {
           "description": "status of build",
           "enum": [
@@ -3178,6 +4120,13 @@
             ]
           },
           "title": "List"
+        },
+        {
+          "description": "Destroy a build cache.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/build-cache",
+          "method": "DELETE",
+          "rel": "empty",
+          "title": "Delete cache"
         }
       ],
       "properties": {
@@ -3223,6 +4172,9 @@
             "object",
             "null"
           ]
+        },
+        "stack": {
+          "$ref": "#/definitions/build/definitions/stack"
         },
         "status": {
           "$ref": "#/definitions/build/definitions/status"
@@ -3817,6 +4769,24 @@
         "object"
       ],
       "definitions": {
+        "acm_status": {
+          "description": "status of this record's ACM",
+          "example": "pending",
+          "readOnly": true,
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "acm_status_reason": {
+          "description": "reason for the status of this record's ACM",
+          "example": "Failing CCA check",
+          "readOnly": true,
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "created_at": {
           "description": "when domain was created",
           "example": "2012-01-01T12:00:00Z",
@@ -3954,6 +4924,12 @@
         }
       ],
       "properties": {
+        "acm_status": {
+          "$ref": "#/definitions/domain/definitions/acm_status"
+        },
+        "acm_status_reason": {
+          "$ref": "#/definitions/domain/definitions/acm_status_reason"
+        },
         "app": {
           "description": "app that owns the domain",
           "properties": {
@@ -4339,7 +5315,7 @@
           "method": "DELETE",
           "rel": "empty",
           "targetSchema": {
-            "additionalPoperties": false,
+            "additionalProperties": false,
             "type": [
               "object"
             ]
@@ -4352,7 +5328,7 @@
           "method": "DELETE",
           "rel": "empty",
           "targetSchema": {
-            "additionalPoperties": false,
+            "additionalProperties": false,
             "type": [
               "object"
             ]
@@ -4365,7 +5341,7 @@
           "method": "POST",
           "rel": "empty",
           "targetSchema": {
-            "additionalPoperties": false,
+            "additionalProperties": false,
             "type": [
               "object"
             ]
@@ -4458,7 +5434,7 @@
       }
     },
     "event": {
-      "description": "An event represents an action performed on another API resource.",
+      "description": "Deprecated: An event represents an action performed on another API resource.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "development",
       "strictProperties": true,
@@ -4690,7 +5666,7 @@
       }
     },
     "failed-event": {
-      "description": "A failed event represents a failure of an action performed on another API resource.",
+      "description": "Deprecated: A failed event represents a failure of an action performed on another API resource.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "development",
       "strictProperties": true,
@@ -5550,210 +6526,6 @@
         }
       }
     },
-    "invitation": {
-      "description": "An invitation represents an invite sent to a user to use the Heroku platform.",
-      "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "stability": "production",
-      "strictProperties": true,
-      "title": "Heroku Platform API - Invitation",
-      "type": [
-        "object"
-      ],
-      "definitions": {
-        "created_at": {
-          "description": "when invitation was created",
-          "example": "2012-01-01T12:00:00Z",
-          "format": "date-time",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "identity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/invitation/definitions/token"
-            }
-          ]
-        },
-        "receive_newsletter": {
-          "description": "whether this user should receive a newsletter or not",
-          "example": false,
-          "readOnly": true,
-          "type": [
-            "boolean"
-          ]
-        },
-        "verification_required": {
-          "description": "if the invitation requires verification",
-          "example": false,
-          "readOnly": true,
-          "type": [
-            "boolean"
-          ]
-        },
-        "token": {
-          "description": "Unique identifier of an invitation",
-          "example": "01234567-89ab-cdef-0123-456789abcdef",
-          "format": "uuid",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "phone_number": {
-          "description": "Phone number to send verification code",
-          "example": "+1 123-123-1234",
-          "type": [
-            "string"
-          ]
-        },
-        "method": {
-          "description": "Transport used to send verification code",
-          "example": "sms",
-          "default": "sms",
-          "type": [
-            "string"
-          ],
-          "enum": [
-            "call",
-            "sms"
-          ]
-        },
-        "verification_code": {
-          "description": "Value used to verify invitation",
-          "example": "123456",
-          "type": [
-            "string"
-          ]
-        }
-      },
-      "links": [
-        {
-          "description": "Info for invitation.",
-          "href": "/invitations/{(%23%2Fdefinitions%2Finvitation%2Fdefinitions%2Fidentity)}",
-          "method": "GET",
-          "rel": "self",
-          "title": "Info"
-        },
-        {
-          "description": "Invite a user.",
-          "href": "/invitations",
-          "method": "POST",
-          "rel": "self",
-          "schema": {
-            "properties": {
-              "email": {
-                "$ref": "#/definitions/account/definitions/email"
-              },
-              "name": {
-                "$ref": "#/definitions/account/definitions/name"
-              }
-            },
-            "required": [
-              "email",
-              "name"
-            ],
-            "type": [
-              "object"
-            ]
-          },
-          "title": "Create"
-        },
-        {
-          "description": "Send a verification code for an invitation via SMS/phone call.",
-          "href": "/invitations/{(%23%2Fdefinitions%2Finvitation%2Fdefinitions%2Fidentity)}/actions/send-verification",
-          "method": "POST",
-          "rel": "empty",
-          "schema": {
-            "properties": {
-              "phone_number": {
-                "$ref": "#/definitions/invitation/definitions/phone_number"
-              },
-              "method": {
-                "$ref": "#/definitions/invitation/definitions/method"
-              }
-            },
-            "required": [
-              "phone_number"
-            ],
-            "type": [
-              "object"
-            ]
-          },
-          "title": "Send Verification Code"
-        },
-        {
-          "description": "Verify an invitation using a verification code.",
-          "href": "/invitations/{(%23%2Fdefinitions%2Finvitation%2Fdefinitions%2Fidentity)}/actions/verify",
-          "method": "POST",
-          "rel": "self",
-          "schema": {
-            "properties": {
-              "verification_code": {
-                "$ref": "#/definitions/invitation/definitions/verification_code"
-              }
-            },
-            "required": [
-              "verification_code"
-            ],
-            "type": [
-              "object"
-            ]
-          },
-          "title": "Verify"
-        },
-        {
-          "description": "Finalize Invitation and Create Account.",
-          "href": "/invitations/{(%23%2Fdefinitions%2Finvitation%2Fdefinitions%2Fidentity)}",
-          "method": "PATCH",
-          "rel": "update",
-          "schema": {
-            "properties": {
-              "password": {
-                "$ref": "#/definitions/account/definitions/password"
-              },
-              "password_confirmation": {
-                "$ref": "#/definitions/account/definitions/password"
-              },
-              "receive_newsletter": {
-                "$ref": "#/definitions/invitation/definitions/receive_newsletter"
-              }
-            },
-            "required": [
-              "password",
-              "password_confirmation"
-            ],
-            "type": [
-              "object"
-            ]
-          },
-          "title": "Finalize"
-        }
-      ],
-      "properties": {
-        "verification_required": {
-          "$ref": "#/definitions/invitation/definitions/verification_required"
-        },
-        "created_at": {
-          "$ref": "#/definitions/invitation/definitions/created_at"
-        },
-        "user": {
-          "properties": {
-            "email": {
-              "$ref": "#/definitions/account/definitions/email"
-            },
-            "id": {
-              "$ref": "#/definitions/account/definitions/id"
-            }
-          },
-          "strictProperties": true,
-          "type": [
-            "object"
-          ]
-        }
-      }
-    },
     "invoice-address": {
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "description": "An invoice address represents the address that should be listed on an invoice.",
@@ -6343,6 +7115,21 @@
             "$ref": "#/definitions/log-drain"
           },
           "title": "Info"
+        },
+        {
+          "description": "List existing log drains for an add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/log-drains",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/log-drain"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List By Add-on"
         },
         {
           "description": "List existing log drains.",
@@ -7532,21 +8319,6 @@
           "title": "Create"
         },
         {
-          "description": "List apps in the default organization, or in personal account, if default organization is not set.",
-          "href": "/organizations/apps",
-          "method": "GET",
-          "rel": "instances",
-          "targetSchema": {
-            "items": {
-              "$ref": "#/definitions/organization-app"
-            },
-            "type": [
-              "array"
-            ]
-          },
-          "title": "List"
-        },
-        {
           "description": "List organization apps.",
           "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/apps",
           "method": "GET",
@@ -7641,6 +8413,20 @@
         },
         "buildpack_provided_description": {
           "$ref": "#/definitions/app/definitions/buildpack_provided_description"
+        },
+        "build_stack": {
+          "description": "identity of the stack that will be used for new builds",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/stack/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/stack/definitions/name"
+            }
+          },
+          "type": [
+            "object"
+          ]
         },
         "created_at": {
           "$ref": "#/definitions/app/definitions/created_at"
@@ -10626,6 +11412,15 @@
           "type": [
             "boolean"
           ]
+        },
+        "output_stream_url": {
+          "description": "Release command output will be available from this URL as a stream. The stream is available as either `text/plain` or `text/event-stream`. Clients should be prepared to handle disconnects and can resume the stream by sending a `Range` header (for `text/plain`) or a `Last-Event-Id` header (for `text/event-stream`).",
+          "example": "https://release-output.heroku.com/streams/01234567-89ab-cdef-0123-456789abcdef",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "links": [
@@ -10776,6 +11571,9 @@
         },
         "current": {
           "$ref": "#/definitions/release/definitions/current"
+        },
+        "output_stream_url": {
+          "$ref": "#/definitions/release/definitions/output_stream_url"
         }
       }
     },
@@ -11731,8 +12529,8 @@
               "name": {
                 "$ref": "#/definitions/space/definitions/name"
               },
-              "organization": {
-                "$ref": "#/definitions/organization/definitions/name"
+              "team": {
+                "$ref": "#/definitions/team/definitions/name"
               },
               "region": {
                 "$ref": "#/definitions/region/definitions/identity"
@@ -11743,7 +12541,7 @@
             },
             "required": [
               "name",
-              "organization"
+              "team"
             ],
             "type": [
               "object"
@@ -12459,21 +13257,6 @@
           "title": "Create"
         },
         {
-          "description": "List apps in the default team, or in personal account, if default team is not set.",
-          "href": "/teams/apps",
-          "method": "GET",
-          "rel": "instances",
-          "targetSchema": {
-            "items": {
-              "$ref": "#/definitions/team-app"
-            },
-            "type": [
-              "array"
-            ]
-          },
-          "title": "List"
-        },
-        {
           "description": "Info for a team app.",
           "href": "/teams/apps/{(%23%2Fdefinitions%2Fteam-app%2Fdefinitions%2Fidentity)}",
           "method": "GET",
@@ -12568,6 +13351,20 @@
         },
         "buildpack_provided_description": {
           "$ref": "#/definitions/app/definitions/buildpack_provided_description"
+        },
+        "build_stack": {
+          "description": "identity of the stack that will be used for new builds",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/stack/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/stack/definitions/name"
+            }
+          },
+          "type": [
+            "object"
+          ]
         },
         "created_at": {
           "$ref": "#/definitions/app/definitions/created_at"
@@ -14402,6 +15199,15 @@
     "add-on-service": {
       "$ref": "#/definitions/add-on-service"
     },
+    "add-on-webhook-delivery": {
+      "$ref": "#/definitions/add-on-webhook-delivery"
+    },
+    "add-on-webhook-event": {
+      "$ref": "#/definitions/add-on-webhook-event"
+    },
+    "add-on-webhook": {
+      "$ref": "#/definitions/add-on-webhook"
+    },
     "add-on": {
       "$ref": "#/definitions/add-on"
     },
@@ -14416,6 +15222,15 @@
     },
     "app-transfer": {
       "$ref": "#/definitions/app-transfer"
+    },
+    "app-webhook-delivery": {
+      "$ref": "#/definitions/app-webhook-delivery"
+    },
+    "app-webhook-event": {
+      "$ref": "#/definitions/app-webhook-event"
+    },
+    "app-webhook": {
+      "$ref": "#/definitions/app-webhook"
     },
     "app": {
       "$ref": "#/definitions/app"
@@ -14464,9 +15279,6 @@
     },
     "inbound-ruleset": {
       "$ref": "#/definitions/inbound-ruleset"
-    },
-    "invitation": {
-      "$ref": "#/definitions/invitation"
     },
     "invoice-address": {
       "$ref": "#/definitions/invoice-address"
@@ -14621,12 +15433,14 @@
   "links": [
     {
       "href": "https://api.heroku.com",
-      "rel": "self"
+      "rel": "self",
+      "title": "Index"
     },
     {
       "href": "/schema",
       "method": "GET",
       "rel": "self",
+      "title": "Schema",
       "targetSchema": {
         "additionalProperties": true
       }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -227,10 +227,10 @@
 			"revisionTime": "2017-07-27T06:48:18Z"
 		},
 		{
-			"checksumSHA1": "ySg+wxsWmk5AipJDFGGG2JhxIPU=",
+			"checksumSHA1": "CQnNhfHXJ63eo4LvEQwtv2Nt12Q=",
 			"path": "github.com/cyberdelia/heroku-go/v3",
-			"revision": "84e6d0171b96992458bcbc5609d28b35edf26f00",
-			"revisionTime": "2017-05-16T20:23:11Z"
+			"revision": "bb8b6b1e9656ec0728638961f8e8b4211fee735d",
+			"revisionTime": "2017-10-06T18:42:27Z"
 		},
 		{
 			"checksumSHA1": "dvabztWVQX8f6oMLRyv4dLH+TGY=",


### PR DESCRIPTION
Changing an app stack doesn't require a fully new resource, though it will require a new build.

This also changes the retrieved stack data from `stack.name` to `build_stack.name. The stack attribute represents the stack from the latest build, whereas build_stack represents the stack that will be used on the app from now on.