### PR TITLE
r/heroku_app: always read all config vars

### DIFF
--- a/heroku/import_heroku_app_test.go
+++ b/heroku/import_heroku_app_test.go
@@ -21,10 +21,9 @@ func TestAccHerokuApp_importBasic(t *testing.T) {
 				Config: testAccCheckHerokuAppConfig_basic(appName),
 			},
 			{
-				ResourceName:            "heroku_app.foobar",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"config_vars"},
+				ResourceName:      "heroku_app.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -48,10 +47,9 @@ func TestAccHerokuApp_importOrganization(t *testing.T) {
 				Config: testAccCheckHerokuAppConfig_organization(appName, org),
 			},
 			{
-				ResourceName:            "heroku_app.foobar",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"config_vars"},
+				ResourceName:      "heroku_app.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/heroku/resource_heroku_app.go
+++ b/heroku/resource_heroku_app.go
@@ -146,8 +146,9 @@ func resourceHerokuApp() *schema.Resource {
 			},
 
 			"all_config_vars": {
-				Type:     schema.TypeMap,
-				Computed: true,
+				Type:       schema.TypeMap,
+				Computed:   true,
+				Deprecated: "Please reference config_vars instead",
 			},
 
 			"git_url": {
@@ -330,40 +331,22 @@ func resourceHerokuOrgAppCreate(d *schema.ResourceData, meta interface{}) error 
 func resourceHerokuAppRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*heroku.Service)
 
-	configVars := make(map[string]string)
-	care := make(map[string]struct{})
-	for _, v := range d.Get("config_vars").([]interface{}) {
-		// Protect against panic on type cast for a nil-length array or map
-		n, ok := v.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		for k := range n {
-			care[k] = struct{}{}
-		}
-	}
-
 	// Only track buildpacks when set in the configuration.
 	_, buildpacksConfigured := d.GetOk("buildpacks")
 
 	organizationApp := isOrganizationApp(d)
 
-	// Only set the config_vars that we have set in the configuration.
-	// The "all_config_vars" field has all of them.
+	// The "all_config_vars" field has all config vars, but will go away, instead
+	// you should just reference config_vars, which will also have them all. This
+	// is done to detect drift in config vars.
 	app, err := resourceHerokuAppRetrieve(d.Id(), organizationApp, client)
 	if err != nil {
 		return err
 	}
 
-	for k, v := range app.Vars {
-		if _, ok := care[k]; ok {
-			configVars[k] = v
-		}
-	}
-
 	var configVarsValue []map[string]string
-	if len(configVars) > 0 {
-		configVarsValue = []map[string]string{configVars}
+	if len(app.Vars) > 0 {
+		configVarsValue = []map[string]string{app.Vars}
 	}
 
 	d.Set("name", app.App.Name)
@@ -374,8 +357,14 @@ func resourceHerokuAppRead(d *schema.ResourceData, meta interface{}) error {
 	if buildpacksConfigured {
 		d.Set("buildpacks", app.Buildpacks)
 	}
-	d.Set("config_vars", configVarsValue)
-	d.Set("all_config_vars", app.Vars)
+
+	if err := d.Set("config_vars", configVarsValue); err != nil {
+		log.Printf("[WARN] Error setting config vars: %s", err)
+	}
+	if err := d.Set("all_config_vars", app.Vars); err != nil {
+		log.Printf("[WARN] Error setting all_config_vars: %s", err)
+	}
+
 	if organizationApp {
 		d.Set("space", app.App.Space)
 


### PR DESCRIPTION
The current implementation of `resource_heroku_app` only reads values for configuration variables for values defined in the current Terraform configuration files. This is counter to how Terraform Resources generally work. Unless there is an extreme circumstance, Terraform Resources should read all supported values regardless if they are set locally, so that a user can detect configuration drift. 

Consider this config:

```hcl
provider "heroku" {}

resource "heroku_app" "test_config_vars" {
  name   = "test-config-vars"
  region = "us"

  config_vars {
    OTHER_TOKEN = "twothree4"
    LAST_TOKEN  = "threefour5"
    EDIT        = "ok"
    NEW         = "best"
    MORE        = "another"
  }
}
```

If another user were to add additional configuration variables via the Web or API outside of Terraform, the current implementation would not detect it. I found this by importing an app with vars and none in my config, and no diff was detected.

In this patch, we read and save all configuration values. The `all_config_vars` (?) attribute should be removed in a future release. 

Test results after the patch:

```
TF_ACC=1 go test ./heroku -v -run=TestAccHerokuApp -timeout 120m
=== RUN   TestAccHerokuApp_importBasic
--- PASS: TestAccHerokuApp_importBasic (2.68s)
=== RUN   TestAccHerokuApp_importOrganization
--- PASS: TestAccHerokuApp_importOrganization (2.62s)
=== RUN   TestAccHerokuAppFeature
--- PASS: TestAccHerokuAppFeature (4.52s)
=== RUN   TestAccHerokuApp_Basic
--- PASS: TestAccHerokuApp_Basic (2.33s)
=== RUN   TestAccHerokuApp_NameChange
--- PASS: TestAccHerokuApp_NameChange (4.12s)
=== RUN   TestAccHerokuApp_NukeVars
--- PASS: TestAccHerokuApp_NukeVars (3.61s)
=== RUN   TestAccHerokuApp_Buildpacks
--- PASS: TestAccHerokuApp_Buildpacks (5.53s)
=== RUN   TestAccHerokuApp_ExternallySetBuildpacks
--- PASS: TestAccHerokuApp_ExternallySetBuildpacks (3.28s)
=== RUN   TestAccHerokuApp_Organization
--- PASS: TestAccHerokuApp_Organization (2.20s)
=== RUN   TestAccHerokuApp_Space
--- PASS: TestAccHerokuApp_Space (420.77s)
=== RUN   TestAccHerokuApp_EmptyConfigVars
--- PASS: TestAccHerokuApp_EmptyConfigVars (1.94s)
PASS
ok      github.com/terraform-providers/terraform-provider-heroku/heroku 453.635s
```