### PR TITLE
r/heroku_addon: Making the `config_vars` field Optional + Computed

### DIFF
--- a/heroku/resource_heroku_app.go
+++ b/heroku/resource_heroku_app.go
@@ -141,6 +141,7 @@ func resourceHerokuApp() *schema.Resource {
 			"config_vars": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeMap,
 				},


### PR DESCRIPTION
Fixes a test failure in `TestAccHerokuAddon_noPlan`

```
$ acctests heroku TestAccHerokuAddon_
=== RUN   TestAccHerokuAddon_importBasic
--- PASS: TestAccHerokuAddon_importBasic (10.34s)
=== RUN   TestAccHerokuAddon_Basic
--- PASS: TestAccHerokuAddon_Basic (5.49s)
=== RUN   TestAccHerokuAddon_noPlan
--- PASS: TestAccHerokuAddon_noPlan (8.64s)
=== RUN   TestAccHerokuAddon_Disappears
--- PASS: TestAccHerokuAddon_Disappears (5.62s)
PASS
ok      github.com/terraform-providers/terraform-provider-heroku/heroku    30.105s
```