### PR TITLE
Fixing `TestAccHerokuApp_NukeVars`

### DIFF
--- a/heroku/resource_heroku_app_test.go
+++ b/heroku/resource_heroku_app_test.go
@@ -621,6 +621,8 @@ func testAccCheckHerokuAppConfig_no_vars(appName string) string {
 resource "heroku_app" "foobar" {
   name   = "%s"
   region = "us"
+
+  config_vars = []
 }`, appName)
 }
 


### PR DESCRIPTION
Forgot to also run the tests for `TestAccHerokuApp_` in #22 🤦‍♂️ - this fixes the broken `TestAccHerokuApp_NukeVars` test

```
$ acctests heroku TestAccHerokuApp_
=== RUN   TestAccHerokuApp_importBasic
--- PASS: TestAccHerokuApp_importBasic (4.84s)
=== RUN   TestAccHerokuApp_importOrganization
--- SKIP: TestAccHerokuApp_importOrganization (0.00s)
	import_heroku_app_test.go:41: HEROKU_ORGANIZATION is not set; skipping test.
=== RUN   TestAccHerokuApp_Basic
--- PASS: TestAccHerokuApp_Basic (3.86s)
=== RUN   TestAccHerokuApp_Disappears
--- PASS: TestAccHerokuApp_Disappears (2.12s)
=== RUN   TestAccHerokuApp_Change
--- PASS: TestAccHerokuApp_Change (7.88s)
=== RUN   TestAccHerokuApp_NukeVars
--- PASS: TestAccHerokuApp_NukeVars (8.18s)
=== RUN   TestAccHerokuApp_Buildpacks
--- PASS: TestAccHerokuApp_Buildpacks (12.29s)
=== RUN   TestAccHerokuApp_ExternallySetBuildpacks
--- PASS: TestAccHerokuApp_ExternallySetBuildpacks (7.17s)
=== RUN   TestAccHerokuApp_Organization
--- SKIP: TestAccHerokuApp_Organization (0.00s)
	resource_heroku_app_test.go:220: HEROKU_ORGANIZATION is not set; skipping test.
=== RUN   TestAccHerokuApp_Space
--- SKIP: TestAccHerokuApp_Space (0.00s)
	resource_heroku_app_test.go:247: HEROKU_ORGANIZATION is not set; skipping test.
=== RUN   TestAccHerokuApp_EmptyConfigVars
--- PASS: TestAccHerokuApp_EmptyConfigVars (3.46s)
PASS
ok  	github.com/terraform-providers/terraform-provider-heroku/heroku	49.820s
```

tests for `TestAccHerokuAddon_` are still passing:

```
$ acctests heroku TestAccHerokuAddon_
=== RUN   TestAccHerokuAddon_importBasic
--- PASS: TestAccHerokuAddon_importBasic (8.93s)
=== RUN   TestAccHerokuAddon_Basic
--- PASS: TestAccHerokuAddon_Basic (9.21s)
=== RUN   TestAccHerokuAddon_noPlan
--- PASS: TestAccHerokuAddon_noPlan (10.25s)
=== RUN   TestAccHerokuAddon_Disappears
--- PASS: TestAccHerokuAddon_Disappears (4.80s)
PASS
ok  	github.com/terraform-providers/terraform-provider-heroku/heroku	33.207s
```