### PR TITLE
Confirm add-on creation

### DIFF
--- a/heroku/resource_heroku_addon.go
+++ b/heroku/resource_heroku_addon.go
@@ -80,7 +80,10 @@ func resourceHerokuAddonCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*heroku.Service)
 
 	app := d.Get("app").(string)
-	opts := heroku.AddOnCreateOpts{Plan: d.Get("plan").(string)}
+	opts := heroku.AddOnCreateOpts{
+		Plan:    d.Get("plan").(string),
+		Confirm: &app,
+	}
 
 	if v := d.Get("config"); v != nil {
 		config := make(map[string]string)

--- a/vendor/github.com/cyberdelia/heroku-go/v3/heroku.go
+++ b/vendor/github.com/cyberdelia/heroku-go/v3/heroku.go
@@ -335,6 +335,10 @@ type AddOn struct {
 		ID   string `json:"id" url:"id,key"`     // unique identifier of app
 		Name string `json:"name" url:"name,key"` // unique name of app
 	} `json:"app" url:"app,key"` // billing application associated with this add-on
+	BilledPrice *struct {
+		Cents int    `json:"cents" url:"cents,key"` // price in cents per unit of plan
+		Unit  string `json:"unit" url:"unit,key"`   // unit of price for plan
+	} `json:"billed_price" url:"billed_price,key"` // billed price
 	ConfigVars []string  `json:"config_vars" url:"config_vars,key"` // config vars exposed to the owning app by this add-on
 	CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when add-on was created
 	ID         string    `json:"id" url:"id,key"`                   // unique identifier of add-on
@@ -365,6 +369,7 @@ func (s *Service) AddOnInfo(ctx context.Context, addOnIdentity string) (*AddOn, 
 type AddOnCreateOpts struct {
 	Attachment *struct{}          `json:"attachment,omitempty" url:"attachment,omitempty,key"` // name for add-on's initial attachment
 	Config     *map[string]string `json:"config,omitempty" url:"config,omitempty,key"`         // custom add-on provisioning options
+	Confirm    *string            `json:"confirm,omitempty" url:"confirm,omitempty,key"`       // name of owning app for confirmation
 	Plan       string             `json:"plan" url:"plan,key"`                                 // unique identifier of this plan
 }
 
@@ -436,6 +441,10 @@ type AddOnActionProvisionResult struct {
 		ID   string `json:"id" url:"id,key"`     // unique identifier of app
 		Name string `json:"name" url:"name,key"` // unique name of app
 	} `json:"app" url:"app,key"` // billing application associated with this add-on
+	BilledPrice *struct {
+		Cents int    `json:"cents" url:"cents,key"` // price in cents per unit of plan
+		Unit  string `json:"unit" url:"unit,key"`   // unit of price for plan
+	} `json:"billed_price" url:"billed_price,key"` // billed price
 	ConfigVars []string  `json:"config_vars" url:"config_vars,key"` // config vars exposed to the owning app by this add-on
 	CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when add-on was created
 	ID         string    `json:"id" url:"id,key"`                   // unique identifier of add-on
@@ -466,6 +475,10 @@ type AddOnActionDeprovisionResult struct {
 		ID   string `json:"id" url:"id,key"`     // unique identifier of app
 		Name string `json:"name" url:"name,key"` // unique name of app
 	} `json:"app" url:"app,key"` // billing application associated with this add-on
+	BilledPrice *struct {
+		Cents int    `json:"cents" url:"cents,key"` // price in cents per unit of plan
+		Unit  string `json:"unit" url:"unit,key"`   // unit of price for plan
+	} `json:"billed_price" url:"billed_price,key"` // billed price
 	ConfigVars []string  `json:"config_vars" url:"config_vars,key"` // config vars exposed to the owning app by this add-on
 	CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when add-on was created
 	ID         string    `json:"id" url:"id,key"`                   // unique identifier of add-on
@@ -513,9 +526,10 @@ type AddOnAttachment struct {
 	WebURL    *string   `json:"web_url" url:"web_url,key"`       // URL for logging into web interface of add-on in attached app context
 }
 type AddOnAttachmentCreateOpts struct {
-	Addon string `json:"addon" url:"addon,key"`                     // unique identifier of add-on
-	App   string `json:"app" url:"app,key"`                         // unique identifier of app
-	Force *bool  `json:"force,omitempty" url:"force,omitempty,key"` // whether or not to allow existing attachment with same name to be
+	Addon   string  `json:"addon" url:"addon,key"`                         // unique identifier of add-on
+	App     string  `json:"app" url:"app,key"`                             // unique identifier of app
+	Confirm *string `json:"confirm,omitempty" url:"confirm,omitempty,key"` // name of owning app for confirmation
+	Force   *bool   `json:"force,omitempty" url:"force,omitempty,key"`     // whether or not to allow existing attachment with same name to be
 	// replaced
 	Name      *string `json:"name,omitempty" url:"name,omitempty,key"`           // unique name for this add-on attachment to this app
 	Namespace *string `json:"namespace,omitempty" url:"namespace,omitempty,key"` // attachment namespace
@@ -1878,66 +1892,6 @@ func (s *Service) DynoSizeList(ctx context.Context, lr *ListRange) (DynoSizeList
 	return dynoSize, s.Get(ctx, &dynoSize, fmt.Sprintf("/dyno-sizes"), nil, lr)
 }
 
-// Deprecated: An event represents an action performed on another API
-// resource.
-type Event struct {
-	Action string `json:"action" url:"action,key"` // the operation performed on the resource
-	Actor  struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"actor" url:"actor,key"` // user that performed the operation
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when the event was created
-	Data      struct {
-		AllowTracking       bool      `json:"allow_tracking" url:"allow_tracking,key"` // whether to allow third party web activity tracking
-		Beta                bool      `json:"beta" url:"beta,key"`                     // whether allowed to utilize beta Heroku features
-		CreatedAt           time.Time `json:"created_at" url:"created_at,key"`         // when account was created
-		DefaultOrganization *struct {
-			ID   string `json:"id" url:"id,key"`     // unique identifier of organization
-			Name string `json:"name" url:"name,key"` // unique name of organization
-		} `json:"default_organization" url:"default_organization,key"` // organization selected by default
-		DelinquentAt     *time.Time `json:"delinquent_at" url:"delinquent_at,key"` // when account became delinquent
-		Email            string     `json:"email" url:"email,key"`                 // unique email address of account
-		Federated        bool       `json:"federated" url:"federated,key"`         // whether the user is federated and belongs to an Identity Provider
-		ID               string     `json:"id" url:"id,key"`                       // unique identifier of an account
-		IdentityProvider *struct {
-			ID           string `json:"id" url:"id,key"` // unique identifier of this identity provider
-			Organization struct {
-				Name string `json:"name" url:"name,key"` // unique name of organization
-			} `json:"organization" url:"organization,key"`
-		} `json:"identity_provider" url:"identity_provider,key"` // Identity Provider details for federated users.
-		LastLogin               *time.Time `json:"last_login" url:"last_login,key"`                               // when account last authorized with Heroku
-		Name                    *string    `json:"name" url:"name,key"`                                           // full name of the account owner
-		SmsNumber               *string    `json:"sms_number" url:"sms_number,key"`                               // SMS number of account
-		SuspendedAt             *time.Time `json:"suspended_at" url:"suspended_at,key"`                           // when account was suspended
-		TwoFactorAuthentication bool       `json:"two_factor_authentication" url:"two_factor_authentication,key"` // whether two-factor auth is enabled on the account
-		UpdatedAt               time.Time  `json:"updated_at" url:"updated_at,key"`                               // when account was updated
-		Verified                bool       `json:"verified" url:"verified,key"`                                   // whether account has been verified with billing information
-	} `json:"data" url:"data,key"` // An account represents an individual signed up to use the Heroku
-	// platform.
-	ID           string     `json:"id" url:"id,key"`                       // unique identifier of an event
-	PreviousData struct{}   `json:"previous_data" url:"previous_data,key"` // data fields that were changed during update with previous values
-	PublishedAt  *time.Time `json:"published_at" url:"published_at,key"`   // when the event was published
-	Resource     string     `json:"resource" url:"resource,key"`           // the type of resource affected
-	Sequence     *string    `json:"sequence" url:"sequence,key"`           // a numeric string representing the event's sequence
-	UpdatedAt    time.Time  `json:"updated_at" url:"updated_at,key"`       // when the event was updated (same as created)
-	Version      string     `json:"version" url:"version,key"`             // the event's API version string
-}
-
-// Deprecated: A failed event represents a failure of an action
-// performed on another API resource.
-type FailedEvent struct {
-	Action   string  `json:"action" url:"action,key"`     // The attempted operation performed on the resource.
-	Code     *int    `json:"code" url:"code,key"`         // An HTTP status code.
-	ErrorID  *string `json:"error_id" url:"error_id,key"` // ID of error raised.
-	Message  string  `json:"message" url:"message,key"`   // A detailed error message.
-	Method   string  `json:"method" url:"method,key"`     // The HTTP method type of the failed action.
-	Path     string  `json:"path" url:"path,key"`         // The path of the attempted operation.
-	Resource *struct {
-		ID   string `json:"id" url:"id,key"`     // Unique identifier of a resource.
-		Name string `json:"name" url:"name,key"` // the type of resource affected
-	} `json:"resource" url:"resource,key"` // The related resource of the failed action.
-}
-
 // Filters are special endpoints to allow for API consumers to specify a
 // subset of resources to consume in order to reduce the number of
 // requests that are performed.  Each filter endpoint endpoint is
@@ -2317,6 +2271,16 @@ func (s *Service) LogDrainCreate(ctx context.Context, appIdentity string, o LogD
 	return &logDrain, s.Post(ctx, &logDrain, fmt.Sprintf("/apps/%v/log-drains", appIdentity), o)
 }
 
+type LogDrainUpdateOpts struct {
+	URL string `json:"url" url:"url,key"` // url associated with the log drain
+}
+
+// Update an add-on owned log drain.
+func (s *Service) LogDrainUpdate(ctx context.Context, addOnIdentity string, logDrainQueryIdentity string, o LogDrainUpdateOpts) (*LogDrain, error) {
+	var logDrain LogDrain
+	return &logDrain, s.Put(ctx, &logDrain, fmt.Sprintf("/addons/%v/log-drains/%v", addOnIdentity, logDrainQueryIdentity), o)
+}
+
 // Delete an existing log drain. Log drains added by add-ons can only be
 // removed by removing the add-on.
 func (s *Service) LogDrainDelete(ctx context.Context, appIdentity string, logDrainQueryIdentity string) (*LogDrain, error) {
@@ -2654,6 +2618,10 @@ type OrganizationAddOnListForOrganizationResult []struct {
 		ID   string `json:"id" url:"id,key"`     // unique identifier of app
 		Name string `json:"name" url:"name,key"` // unique name of app
 	} `json:"app" url:"app,key"` // billing application associated with this add-on
+	BilledPrice *struct {
+		Cents int    `json:"cents" url:"cents,key"` // price in cents per unit of plan
+		Unit  string `json:"unit" url:"unit,key"`   // unit of price for plan
+	} `json:"billed_price" url:"billed_price,key"` // billed price
 	ConfigVars []string  `json:"config_vars" url:"config_vars,key"` // config vars exposed to the owning app by this add-on
 	CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when add-on was created
 	ID         string    `json:"id" url:"id,key"`                   // unique identifier of add-on
@@ -3993,7 +3961,7 @@ func (s *Service) TeamDelete(ctx context.Context, teamIdentity string) (*Team, e
 	return &team, s.Delete(ctx, &team, fmt.Sprintf("/teams/%v", teamIdentity))
 }
 
-// An team app encapsulates the team specific functionality of Heroku
+// A team app encapsulates the team specific functionality of Heroku
 // apps.
 type TeamApp struct {
 	ArchivedAt *time.Time `json:"archived_at" url:"archived_at,key"` // when app was archived

--- a/vendor/github.com/cyberdelia/heroku-go/v3/schema.json
+++ b/vendor/github.com/cyberdelia/heroku-go/v3/schema.json
@@ -584,6 +584,13 @@
         "object"
       ],
       "definitions": {
+        "confirm": {
+          "description": "name of owning app for confirmation",
+          "example": "example",
+          "type": [
+            "string"
+          ]
+        },
         "created_at": {
           "description": "when add-on attachment was created",
           "example": "2012-01-01T12:00:00Z",
@@ -678,6 +685,9 @@
               },
               "app": {
                 "$ref": "#/definitions/app/definitions/identity"
+              },
+              "confirm": {
+                "$ref": "#/definitions/add-on-attachment/definitions/confirm"
               },
               "force": {
                 "$ref": "#/definitions/add-on-attachment/definitions/force"
@@ -1583,6 +1593,14 @@
             }
           }
         },
+        "cents": {
+          "description": "price in cents per unit of add-on",
+          "example": 0,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
         "config_vars": {
           "description": "config vars exposed to the owning app by this add-on",
           "example": [
@@ -1597,6 +1615,13 @@
           "readOnly": true,
           "type": [
             "array"
+          ]
+        },
+        "confirm": {
+          "description": "name of owning app for confirmation",
+          "example": "example",
+          "type": [
+            "string"
           ]
         },
         "created_at": {
@@ -1652,6 +1677,14 @@
             "deprovisioned"
           ],
           "example": "provisioned",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "unit": {
+          "description": "unit of price for add-on",
+          "example": "month",
           "readOnly": true,
           "type": [
             "string"
@@ -1738,6 +1771,9 @@
                 "type": [
                   "object"
                 ]
+              },
+              "confirm": {
+                "$ref": "#/definitions/add-on/definitions/confirm"
               },
               "plan": {
                 "$ref": "#/definitions/plan/definitions/identity"
@@ -1874,6 +1910,22 @@
             }
           },
           "strictProperties": true
+        },
+        "billed_price": {
+          "description": "billed price",
+          "properties": {
+            "cents": {
+              "$ref": "#/definitions/plan/definitions/cents"
+            },
+            "unit": {
+              "$ref": "#/definitions/plan/definitions/unit"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object",
+            "null"
+          ]
         },
         "config_vars": {
           "$ref": "#/definitions/add-on/definitions/config_vars"
@@ -2125,7 +2177,6 @@
           "description": "application process tier",
           "enum": [
             "production",
-            "traditional",
             "free",
             "hobby",
             "private"
@@ -5433,369 +5484,6 @@
         }
       }
     },
-    "event": {
-      "description": "Deprecated: An event represents an action performed on another API resource.",
-      "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "stability": "development",
-      "strictProperties": true,
-      "title": "Heroku Platform API - Event",
-      "type": [
-        "object"
-      ],
-      "definitions": {
-        "action": {
-          "description": "the operation performed on the resource",
-          "enum": [
-            "create",
-            "destroy",
-            "update"
-          ],
-          "example": "create",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "created_at": {
-          "description": "when the event was created",
-          "example": "2012-01-01T12:00:00Z",
-          "format": "date-time",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "data": {
-          "description": "the serialized resource affected by the event",
-          "example": {
-          },
-          "anyOf": [
-            {
-              "$ref": "#/definitions/account"
-            },
-            {
-              "$ref": "#/definitions/add-on"
-            },
-            {
-              "$ref": "#/definitions/add-on-attachment"
-            },
-            {
-              "$ref": "#/definitions/app"
-            },
-            {
-              "$ref": "#/definitions/app-formation-set"
-            },
-            {
-              "$ref": "#/definitions/app-setup"
-            },
-            {
-              "$ref": "#/definitions/app-transfer"
-            },
-            {
-              "$ref": "#/definitions/build"
-            },
-            {
-              "$ref": "#/definitions/collaborator"
-            },
-            {
-              "$ref": "#/definitions/domain"
-            },
-            {
-              "$ref": "#/definitions/dyno"
-            },
-            {
-              "$ref": "#/definitions/failed-event"
-            },
-            {
-              "$ref": "#/definitions/formation"
-            },
-            {
-              "$ref": "#/definitions/inbound-ruleset"
-            },
-            {
-              "$ref": "#/definitions/organization"
-            },
-            {
-              "$ref": "#/definitions/release"
-            },
-            {
-              "$ref": "#/definitions/space"
-            },
-            {
-              "$ref": "#/definitions/team"
-            }
-          ],
-          "readOnly": true,
-          "type": [
-            "object"
-          ]
-        },
-        "id": {
-          "description": "unique identifier of an event",
-          "example": "01234567-89ab-cdef-0123-456789abcdef",
-          "format": "uuid",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "identity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/event/definitions/id"
-            }
-          ]
-        },
-        "published_at": {
-          "description": "when the event was published",
-          "example": "2012-01-01T12:00:00Z",
-          "format": "date-time",
-          "readOnly": true,
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "resource": {
-          "description": "the type of resource affected",
-          "enum": [
-            "addon",
-            "addon-attachment",
-            "app",
-            "app-setup",
-            "app-transfer",
-            "build",
-            "collaborator",
-            "domain",
-            "dyno",
-            "failed-event",
-            "formation",
-            "formation-set",
-            "inbound-ruleset",
-            "organization",
-            "release",
-            "space",
-            "team",
-            "user"
-          ],
-          "example": "app",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "sequence": {
-          "description": "a numeric string representing the event's sequence",
-          "example": "1234567890",
-          "pattern": "^[0-9]{1,128}$",
-          "readOnly": true,
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "updated_at": {
-          "description": "when the event was updated (same as created)",
-          "example": "2012-01-01T12:00:00Z",
-          "format": "date-time",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "version": {
-          "description": "the event's API version string",
-          "example": "application/vnd.heroku+json; version=3",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        }
-      },
-      "links": [
-      ],
-      "properties": {
-        "action": {
-          "$ref": "#/definitions/event/definitions/action"
-        },
-        "actor": {
-          "description": "user that performed the operation",
-          "properties": {
-            "email": {
-              "$ref": "#/definitions/account/definitions/email"
-            },
-            "id": {
-              "$ref": "#/definitions/account/definitions/id"
-            }
-          },
-          "strictProperties": true,
-          "type": [
-            "object"
-          ]
-        },
-        "created_at": {
-          "$ref": "#/definitions/event/definitions/created_at"
-        },
-        "data": {
-          "$ref": "#/definitions/event/definitions/data"
-        },
-        "id": {
-          "$ref": "#/definitions/event/definitions/id"
-        },
-        "previous_data": {
-          "description": "data fields that were changed during update with previous values",
-          "type": [
-            "object"
-          ]
-        },
-        "published_at": {
-          "$ref": "#/definitions/event/definitions/published_at"
-        },
-        "resource": {
-          "$ref": "#/definitions/event/definitions/resource"
-        },
-        "sequence": {
-          "$ref": "#/definitions/event/definitions/sequence"
-        },
-        "updated_at": {
-          "$ref": "#/definitions/event/definitions/updated_at"
-        },
-        "version": {
-          "$ref": "#/definitions/event/definitions/version"
-        }
-      }
-    },
-    "failed-event": {
-      "description": "Deprecated: A failed event represents a failure of an action performed on another API resource.",
-      "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "stability": "development",
-      "strictProperties": true,
-      "title": "Heroku Platform API - Failed Event",
-      "type": [
-        "object"
-      ],
-      "definitions": {
-        "action": {
-          "description": "The attempted operation performed on the resource.",
-          "enum": [
-            "create",
-            "destroy",
-            "update",
-            "unknown"
-          ],
-          "example": "create",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "error_id": {
-          "description": "ID of error raised.",
-          "example": "rate_limit",
-          "readOnly": true,
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "message": {
-          "description": "A detailed error message.",
-          "example": "Your account reached the API rate limit\nPlease wait a few minutes before making new requests",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "method": {
-          "description": "The HTTP method type of the failed action.",
-          "enum": [
-            "DELETE",
-            "GET",
-            "HEAD",
-            "OPTIONS",
-            "PATCH",
-            "POST",
-            "PUT"
-          ],
-          "example": "POST",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "code": {
-          "description": "An HTTP status code.",
-          "example": 404,
-          "readOnly": true,
-          "type": [
-            "integer",
-            "null"
-          ]
-        },
-        "identity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/event/definitions/id"
-            }
-          ]
-        },
-        "path": {
-          "description": "The path of the attempted operation.",
-          "example": "/apps/my-app",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "resource_id": {
-          "description": "Unique identifier of a resource.",
-          "example": "01234567-89ab-cdef-0123-456789abcdef",
-          "format": "uuid",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        }
-      },
-      "links": [
-      ],
-      "properties": {
-        "action": {
-          "$ref": "#/definitions/failed-event/definitions/action"
-        },
-        "code": {
-          "$ref": "#/definitions/failed-event/definitions/code"
-        },
-        "error_id": {
-          "$ref": "#/definitions/failed-event/definitions/error_id"
-        },
-        "message": {
-          "$ref": "#/definitions/failed-event/definitions/message"
-        },
-        "method": {
-          "$ref": "#/definitions/failed-event/definitions/method"
-        },
-        "path": {
-          "$ref": "#/definitions/failed-event/definitions/path"
-        },
-        "resource": {
-          "description": "The related resource of the failed action.",
-          "properties": {
-            "id": {
-              "$ref": "#/definitions/failed-event/definitions/resource_id"
-            },
-            "name": {
-              "$ref": "#/definitions/event/definitions/resource"
-            }
-          },
-          "strictProperties": true,
-          "type": [
-            "object",
-            "null"
-          ]
-        }
-      }
-    },
     "filter-apps": {
       "description": "Filters are special endpoints to allow for API consumers to specify a subset of resources to consume in order to reduce the number of requests that are performed.  Each filter endpoint endpoint is responsible for determining its supported request format.  The endpoints are over POST in order to handle large request bodies without hitting request uri query length limitations, but the requests themselves are idempotent and will not have side effects.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
@@ -7095,6 +6783,29 @@
             "$ref": "#/definitions/log-drain"
           },
           "title": "Create"
+        },
+        {
+          "description": "Update an add-on owned log drain.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/log-drains/{(%23%2Fdefinitions%2Flog-drain%2Fdefinitions%2Fquery_identity)}",
+          "method": "PUT",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "url": {
+                "$ref": "#/definitions/log-drain/definitions/url"
+              }
+            },
+            "required": [
+              "url"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/log-drain"
+          },
+          "title": "Update"
         },
         {
           "description": "Delete an existing log drain. Log drains added by add-ons can only be removed by removing the add-on.",
@@ -13181,7 +12892,7 @@
     },
     "team-app": {
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "description": "An team app encapsulates the team specific functionality of Heroku apps.",
+      "description": "A team app encapsulates the team specific functionality of Heroku apps.",
       "stability": "development",
       "title": "Heroku Platform API - Team App",
       "type": [
@@ -15261,12 +14972,6 @@
     },
     "dyno": {
       "$ref": "#/definitions/dyno"
-    },
-    "event": {
-      "$ref": "#/definitions/event"
-    },
-    "failed-event": {
-      "$ref": "#/definitions/failed-event"
     },
     "filter-apps": {
       "$ref": "#/definitions/filter-apps"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -227,10 +227,10 @@
 			"revisionTime": "2017-07-27T06:48:18Z"
 		},
 		{
-			"checksumSHA1": "CQnNhfHXJ63eo4LvEQwtv2Nt12Q=",
+			"checksumSHA1": "1GBWSUMZONbk4f3p2eKw6XyolkA=",
 			"path": "github.com/cyberdelia/heroku-go/v3",
-			"revision": "bb8b6b1e9656ec0728638961f8e8b4211fee735d",
-			"revisionTime": "2017-10-06T18:42:27Z"
+			"revision": "d33a13b0825428710c82db90e964516917c6f110",
+			"revisionTime": "2017-12-15T19:10:55Z"
 		},
 		{
 			"checksumSHA1": "dvabztWVQX8f6oMLRyv4dLH+TGY=",


### PR DESCRIPTION
Some add-ons require passing the `confirm` attribute to be created.
For example, if we wish to provision a non-private plan within a private space app.