### PR TITLE
heroku: make app importing always use the app name as its ID whenever possible

### DIFF
--- a/heroku/resource_heroku_app.go
+++ b/heroku/resource_heroku_app.go
@@ -215,6 +215,12 @@ func resourceHerokuAppImport(d *schema.ResourceData, m interface{}) ([]*schema.R
 		})
 	}
 
+	// XXX Heroku's API treats app UUID's and names the same. This can cause
+	// confusion as other parts of this provider assume the app NAME is the app
+	// ID, as a lot of the Heroku API will accept BOTH. App ID's aren't very
+	// easy to get, so it makes more sense to just use the name as much as possible.
+	d.SetId(app.Name)
+
 	return []*schema.ResourceData{d}, nil
 }
 


### PR DESCRIPTION
Okay so:

This was discovered while trying to set up terraform configurations for an existing application stack on heroku. We were trying to import resources and ended up using the app UUID's as internally we use them a lot to refer to other applications. However, externally the [API allows both](https://devcenter.heroku.com/articles/platform-api-reference#app). Other parts of this provider assume that the app name is the app ID. This is obviously wrong, but can be addressed fully at a later date.

This patch sets the ID of the app in terraform to the heroku app name when importing a heroku app.