### PR TITLE
Wait until new release has status succeeded when updating config vars

### DIFF
--- a/heroku/resource_heroku_app.go
+++ b/heroku/resource_heroku_app.go
@@ -413,6 +413,13 @@ func resourceHerokuAppUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.SetId(updatedApp.Name)
 
+	if d.HasChange("buildpacks") {
+		err := updateBuildpacks(d.Id(), client, d.Get("buildpacks").([]interface{}))
+		if err != nil {
+			return err
+		}
+	}
+
 	// If the config vars changed, then recalculate those
 	if d.HasChange("config_vars") {
 		o, n := d.GetChange("config_vars")
@@ -425,13 +432,6 @@ func resourceHerokuAppUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		err := updateConfigVars(
 			d.Id(), client, o.([]interface{}), n.([]interface{}))
-		if err != nil {
-			return err
-		}
-	}
-
-	if d.HasChange("buildpacks") {
-		err := updateBuildpacks(d.Id(), client, d.Get("buildpacks").([]interface{}))
 		if err != nil {
 			return err
 		}

--- a/heroku/resource_heroku_app.go
+++ b/heroku/resource_heroku_app.go
@@ -2,12 +2,15 @@ package heroku
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/url"
+	"time"
 
 	"github.com/cyberdelia/heroku-go/v3"
 	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -435,6 +438,29 @@ func resourceHerokuAppUpdate(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return err
 		}
+
+		releases, err := client.ReleaseList(
+			context.TODO(),
+			d.Id(),
+			&heroku.ListRange{Descending: true, Field: "version", Max: 1},
+		)
+		if err != nil {
+			return err
+		}
+		if len(releases) == 0 {
+			return errors.New("no release found")
+		}
+
+		stateConf := &resource.StateChangeConf{
+			Pending: []string{"pending"},
+			Target:  []string{"succeeded"},
+			Refresh: releaseStateRefreshFunc(client, d.Id(), releases[0].ID),
+			Timeout: 20 * time.Minute,
+		}
+
+		if _, err := stateConf.WaitForState(); err != nil {
+			return fmt.Errorf("Error waiting for new release (%s) to succeed: %s", releases[0].ID, err)
+		}
 	}
 
 	return resourceHerokuAppRead(d, meta)
@@ -585,4 +611,18 @@ func performAppPostCreateTasks(d *schema.ResourceData, client *heroku.Service) e
 	}
 
 	return nil
+}
+
+func releaseStateRefreshFunc(client *heroku.Service, appID, releaseID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		release, err := client.ReleaseInfo(context.TODO(), appID, releaseID)
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		// The type conversion here can be dropped when the vendored version of
+		// heroku-go is updated.
+		return (*heroku.Release)(release), release.Status, nil
+	}
 }


### PR DESCRIPTION
Updating a config will create a new release.
If the app is using release phase, it will take a couple minutes before that release is available and used.

This change makes us wait before moving on.
So, for example, if the config var sets credentials and another resource requires those credentials to be set to be created, we shouldn't try creating that second resource until the release is successful.