### PR TITLE
Revert changes to external config_vars deletion

### DIFF
--- a/heroku/import_heroku_app_test.go
+++ b/heroku/import_heroku_app_test.go
@@ -22,9 +22,10 @@ func TestAccHerokuApp_importBasic(t *testing.T) {
 				Config: testAccCheckHerokuAppConfig_basic(appName, appStack),
 			},
 			{
-				ResourceName:      "heroku_app.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "heroku_app.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"config_vars"},
 			},
 		},
 	})
@@ -48,9 +49,10 @@ func TestAccHerokuApp_importOrganization(t *testing.T) {
 				Config: testAccCheckHerokuAppConfig_organization(appName, org),
 			},
 			{
-				ResourceName:      "heroku_app.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "heroku_app.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"config_vars"},
 			},
 		},
 	})

--- a/heroku/resource_heroku_app.go
+++ b/heroku/resource_heroku_app.go
@@ -379,11 +379,19 @@ func resourceHerokuAppRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("region", app.App.Region)
 	d.Set("git_url", app.App.GitURL)
 	d.Set("web_url", app.App.WebURL)
+
 	if buildpacksConfigured {
 		d.Set("buildpacks", app.Buildpacks)
 	}
-	d.Set("config_vars", configVarsValue)
-	d.Set("all_config_vars", app.Vars)
+
+	if err := d.Set("config_vars", configVarsValue); err != nil {
+		log.Printf("[WARN] Error setting config vars: %s", err)
+	}
+
+	if err := d.Set("all_config_vars", app.Vars); err != nil {
+		log.Printf("[WARN] Error setting all_config_vars: %s", err)
+	}
+
 	if organizationApp {
 		d.Set("space", app.App.Space)
 


### PR DESCRIPTION
This reverts changes introduced in #17, which effectively removed `config_vars` which were set on an app externally via the CLI or UI. This had the unintended effect of removing variables added by addons or other desired services from Heroku.

Initially, we planned on adding an `ignore_vars` or `external_config_vars` attributes, which would be a list of config vars to not remove if they were noticed by Terraform. There's a WIP of that implemented here: https://github.com/terraform-providers/terraform-provider-heroku/commit/7223397

After experimenting with this, and discussing with @catsby, we've come to the conclusion that it would be better to just revert these changes. The `external_config_vars` attribute required writing to the state before taking effect, requiring awkward use of `ignore_changes` to cleanly ignore an already-added external config var.

Previous fix attempt which ignored variables from addons. and discussion: #25
Issues: #24, #26, #30

/cc @robertrossmann @JamesBelchamber @JeremyLoy