### PR TITLE
Fix attachment IDs

### DIFF
--- a/heroku/resource_heroku_addon_attachment.go
+++ b/heroku/resource_heroku_addon_attachment.go
@@ -77,8 +77,8 @@ func resourceHerokuAddonAttachmentRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error retrieving addon attachment: %s", err)
 	}
 
-	d.Set("app_id", addonattachment.App.Name)
-	d.Set("addon_id", addonattachment.Addon.Name)
+	d.Set("app_id", addonattachment.App.ID)
+	d.Set("addon_id", addonattachment.Addon.ID)
 	d.Set("name", addonattachment.Name)
 
 	return nil


### PR DESCRIPTION
Fixes #40 

The attachment resource is saving add-on name as add-on ID. This results in a change on every `terraform plan` because add-on name != add-on ID.

```
Terraform will perform the following actions:

heroku_addon_attachment.sumologic (new resource required)
       id:       "5382910f-92d4-4952-bc39-a92de2f87a72" => <computed> (forces new resource)
       addon_id: "sumologic-cubic-53500" => "1c7aa1ef-a6fc-47a4-abbb-b23512fc15a7" (forces new resource)
       app_id:   "sfdc-cb-rt-stg-ore" => "sfdc-cb-rt-stg-ore"
       name:     "SUMOLOGIC" => <computed>

Plan: 1 to add, 0 to change, 1 to destroy.
```

Note the add-on name `sumologic-cubic-53500` has been saved in the state file as the add-on ID for the `heroku_addon_attachment` resource. It should have been saved as `1c7aa1ef-a6fc-47a4-abbb-b23512fc15a7` in the example above, not `sumologic-cubic-53500`.