### PR TITLE
Heroku app datasource

### DIFF
--- a/heroku/data_source_heroku_app.go
+++ b/heroku/data_source_heroku_app.go
@@ -1,0 +1,120 @@
+package heroku
+
+import (
+	"time"
+
+	"github.com/cyberdelia/heroku-go/v3"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceHerokuApp() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceHerokuAppRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"space": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Default:  nil,
+			},
+
+			"region": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Default:  nil,
+			},
+
+			"stack": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Default:  nil,
+			},
+
+			"buildpacks": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"config_vars": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+
+			"git_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"web_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"acm": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"heroku_hostname": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"organization": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"locked": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+
+						"personal": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceHerokuAppRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(*heroku.Service)
+
+	name := d.Get("name").(string)
+	app, err := resourceHerokuAppRetrieve(name, true, client)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(time.Now().UTC().String())
+
+	if app.Organization {
+		err := setOrganizationDetails(d, app)
+		if err != nil {
+			return err
+		}
+	}
+
+	setAppDetails(d, app)
+
+	d.Set("buildpacks", app.Buildpacks)
+	d.Set("config_vars", app.Vars)
+
+	return nil
+}

--- a/heroku/data_source_heroku_app_test.go
+++ b/heroku/data_source_heroku_app_test.go
@@ -1,0 +1,168 @@
+package heroku
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDatasourceHerokuApp_Basic(t *testing.T) {
+	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	appStack := "heroku-16"
+	gitUrl := fmt.Sprintf("https://git.heroku.com/%s.git", appName)
+	webUrl := fmt.Sprintf("https://%s.herokuapp.com/", appName)
+	herokuHostname := fmt.Sprintf("%s.herokuapp.com", appName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuApp_basic(appName, appStack),
+			},
+			{
+				Config: testAccCheckHerokuAppWithDatasource_basic(appName, appStack),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.heroku_app.foobar", "name", appName),
+					resource.TestCheckResourceAttr(
+						"data.heroku_app.foobar", "stack", appStack),
+					resource.TestCheckResourceAttr(
+						"data.heroku_app.foobar", "region", "us"),
+					resource.TestCheckResourceAttr(
+						"data.heroku_app.foobar", "git_url", gitUrl),
+					resource.TestCheckResourceAttr(
+						"data.heroku_app.foobar", "web_url", webUrl),
+					resource.TestCheckResourceAttr(
+						"data.heroku_app.foobar", "config_vars.FOO", "bar"),
+					resource.TestCheckResourceAttr(
+						"data.heroku_app.foobar", "buildpacks.0", "heroku/go"),
+					resource.TestCheckResourceAttr(
+						"data.heroku_app.foobar", "acm", "false"),
+					resource.TestCheckResourceAttr(
+						"data.heroku_app.foobar", "heroku_hostname", herokuHostname),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatasourceHerokuApp_Advanced(t *testing.T) {
+	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	spaceName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := os.Getenv("HEROKU_SPACES_ORGANIZATION")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			if org == "" {
+				t.Skip("HEROKU_SPACES_ORGANIZATION is not set; skipping test.")
+			}
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuApp_advanced(appName, spaceName, org),
+			},
+			{
+				Config: testAccCheckHerokuAppWithDatasource_advanced(appName, spaceName, org),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.heroku_app.foobar", "name", appName),
+					resource.TestCheckResourceAttr(
+						"data.heroku_app.foobar", "organization.0.name", org),
+					resource.TestCheckResourceAttr(
+						"data.heroku_app.foobar", "space", spaceName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckHerokuApp_basic(appName string, stack string) string {
+	return fmt.Sprintf(`
+resource "heroku_app" "foobar" {
+  name   = "%s"
+  stack = "%s"
+  region = "us"
+
+  buildpacks = [
+    "heroku/go"
+  ]
+
+  config_vars {
+    FOO = "bar"
+  }
+}
+`, appName, stack)
+}
+
+func testAccCheckHerokuAppWithDatasource_basic(appName string, stack string) string {
+	return fmt.Sprintf(`
+resource "heroku_app" "foobar" {
+  name   = "%s"
+  stack = "%s"
+  region = "us"
+
+  buildpacks = [
+    "https://github.com/heroku/heroku-buildpack-multi-procfile",
+    "heroku/go"
+	]
+	
+  config_vars {
+    FOO = "bar"
+  }
+}
+
+data "heroku_app" "foobar" {
+  name = "${heroku_app.foobar.name}"
+}
+`, appName, stack)
+}
+
+func testAccCheckHerokuApp_advanced(appName, spaceName, orgName string) string {
+	return fmt.Sprintf(`
+resource "heroku_space" "foobar" {
+  name = "%s"
+  organization = "%s"
+	region = "virginia"
+	trusted_ip_ranges = [ "0.0.0.0/0" ]
+}
+
+resource "heroku_app" "foobar" {
+  name   = "%s"
+  space  = "${heroku_space.foobar.name}"
+  organization {
+    name = "%s"
+  }
+  region = "virginia"
+}
+`, spaceName, orgName, appName, orgName)
+}
+
+func testAccCheckHerokuAppWithDatasource_advanced(appName, spaceName, orgName string) string {
+	return fmt.Sprintf(`
+resource "heroku_space" "foobar" {
+  name = "%s"
+  organization = "%s"
+	region = "virginia"
+	trusted_ip_ranges = [ "0.0.0.0/0" ]
+}
+
+resource "heroku_app" "foobar" {
+  name   = "%s"
+  space  = "${heroku_space.foobar.name}"
+  organization {
+    name = "%s"
+  }
+  region = "virginia"
+}
+
+data "heroku_app" "foobar" {
+  name = "${heroku_app.foobar.name}"
+}
+`, spaceName, orgName, appName, orgName)
+}

--- a/heroku/provider.go
+++ b/heroku/provider.go
@@ -39,6 +39,10 @@ func Provider() terraform.ResourceProvider {
 			"heroku_space":             resourceHerokuSpace(),
 		},
 
+		DataSourcesMap: map[string]*schema.Resource{
+			"heroku_app": dataSourceHerokuApp(),
+		},
+
 		ConfigureFunc: providerConfigure,
 	}
 }

--- a/website/docs/d/app.html.markdown
+++ b/website/docs/d/app.html.markdown
@@ -1,0 +1,54 @@
+---
+layout: "heroku"
+page_title: "Heroku: heroku_app"
+sidebar_current: "docs-heroku-datasource-app-x"
+description: |-
+  Get information on a Heroku App.
+---
+
+# Data Source: heroku_app
+
+Use this data source to get information about a Heroku App.
+
+## Example Usage
+
+```hcl
+# Create a new Heroku app
+data "heroku_app" "default"
+  name   = "my-cool-app"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the application. In Heroku, this is also the
+   unique ID, so it must be unique and have a minimum of 3 characters.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name` - (Required) The name of the application. In Heroku, this is also the
+   unique .
+* `stack` - (Optional) The application stack is what platform to run the application
+   in.
+* `buildpacks` - (Optional) A list of buildpacks that this app uses.
+* `space` - (Optional) The private space in which the app runs. Not present if this is a common runtime app.
+* `region` - (Required) The region in which the app is deployed.
+* `git_url` - (Required) The Git URL for the application. This is used for
+   deploying new versions of the app.
+* `web_url` - (Required) The web (HTTP) URL that the application can be accessed
+   at by default.
+* `heroku_hostname` - (Required) A hostname for the Heroku application, suitable
+   for pointing DNS records.
+* `config_vars` - (Optional) A map of all of the configuration variables for the app.
+* `acm` - (Required) True if Heroku ACM is enabled for this app, false otherwise.
+* `organization` - (Optional) The organization that owns this app, if the app is owned by an organization. The fields for this block are documented below.
+
+The `organization` block supports:
+
+* `name` (string) - The name of the organization.
+* `locked` (boolean)
+* `personal` (boolean)

--- a/website/heroku.erb
+++ b/website/heroku.erb
@@ -10,6 +10,14 @@
         <a href="/docs/providers/heroku/index.html">Heroku Provider</a>
                 </li>
 
+        <li<%= sidebar_current("docs-heroku-datasource") %>>
+        <a href="#">Data Sources</a>
+                <ul class="nav nav-visible">
+                    <li<%= sidebar_current("docs-heroku-datasource-app") %>>
+          <a href="/docs/providers/heroku/d/app.html">heroku_app</a>
+                    </li>
+                </ul>
+
         <li<%= sidebar_current("docs-heroku-resource") %>>
         <a href="#">Resources</a>
                 <ul class="nav nav-visible">


### PR DESCRIPTION
Enables `heroku_app` data objects like this:

```
data "heroku_app" "my_app" {
  name = "my-app"
}
```

Has two tests:
* TestAccDatasourceHerokuApp_Basic (tests attributes common to all apps)
* TestAccDatasourceHerokuApp_Advanced (tests attributes only present in spaces apps)

I have run these tests, and I've also run `TestAccResourceHerokuApp_Basic`, since this involves a refactor of some `heroku_app` functionality.