### PR TITLE
Create a heroku_space data resource.

### DIFF
--- a/heroku/data_source_heroku_space.go
+++ b/heroku/data_source_heroku_space.go
@@ -29,7 +29,7 @@ func dataSourceHerokuSpace() *schema.Resource {
 			},
 
 			"shield": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeBool,
 				Computed: true,
 			},
 
@@ -55,12 +55,7 @@ func dataSourceHerokuSpaceRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("name", name)
 	d.Set("state", space.State)
 	d.Set("organization", space.Organization.Name)
-
-	if space.Shield {
-		d.Set("shield", "on")
-	} else {
-		d.Set("shield", "off")
-	}
+	d.Set("shield", space.Shield)
 
 	return nil
 }

--- a/heroku/data_source_heroku_space.go
+++ b/heroku/data_source_heroku_space.go
@@ -1,0 +1,66 @@
+package heroku
+
+import (
+	"context"
+
+	"github.com/cyberdelia/heroku-go/v3"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceHerokuSpace() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceHerokuSpaceRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"region": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Default:  nil,
+			},
+
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Default:  nil,
+			},
+
+			"shield": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"organization": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceHerokuSpaceRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(*heroku.Service)
+
+	name := d.Get("name").(string)
+	space, err := client.SpaceInfo(context.TODO(), name)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(name)
+	d.Set("region", space.Region.Name)
+	d.Set("name", name)
+	d.Set("state", space.State)
+	d.Set("organization", space.Organization.Name)
+
+	if space.Shield {
+		d.Set("shield", "on")
+	} else {
+		d.Set("shield", "off")
+	}
+
+	return nil
+}

--- a/heroku/data_source_heroku_space_test.go
+++ b/heroku/data_source_heroku_space_test.go
@@ -1,0 +1,65 @@
+package heroku
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDatasourceHerokuSpace_Basic(t *testing.T) {
+	spaceName := fmt.Sprintf("tftest-space-%s", acctest.RandString(10))
+	orgName := os.Getenv("HEROKU_SPACES_ORGANIZATION")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			if orgName == "" {
+				t.Skip("HEROKU_SPACES_ORGANIZATION is not set; skipping test.")
+			}
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuSpace_basic(spaceName, orgName),
+			},
+			{
+				Config: testAccCheckHerokuSpaceWithDatasource_basic(spaceName, orgName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.heroku_app.foobar", "name", spaceName),
+					resource.TestCheckResourceAttr(
+						"data.heroku_app.foobar", "organization", orgName),
+					resource.TestCheckResourceAttr(
+						"data.heroku_app.foobar", "region", "us"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckHerokuSpace_basic(spaceName string, orgName string) string {
+	return fmt.Sprintf(`
+resource "heroku_space" "foobar" {
+  name         = "%s"
+  organization = "%s"
+  region       = "us"
+}
+`, spaceName, orgName)
+}
+
+func testAccCheckHerokuSpaceWithDatasource_basic(spaceName string, orgName string) string {
+	return fmt.Sprintf(`
+resource "heroku_space" "foobar" {
+  name         = "%s"
+  organization = "%s"
+  region       = "us"
+}
+
+data "heroku_app" "foobar" {
+  name = "${heroku_app.foobar.name}"
+}
+`, spaceName, orgName)
+}

--- a/heroku/data_source_heroku_space_test.go
+++ b/heroku/data_source_heroku_space_test.go
@@ -29,11 +29,11 @@ func TestAccDatasourceHerokuSpace_Basic(t *testing.T) {
 				Config: testAccCheckHerokuSpaceWithDatasource_basic(spaceName, orgName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"data.heroku_app.foobar", "name", spaceName),
+						"data.heroku_space.foobar", "name", spaceName),
 					resource.TestCheckResourceAttr(
-						"data.heroku_app.foobar", "organization", orgName),
+						"data.heroku_space.foobar", "organization", orgName),
 					resource.TestCheckResourceAttr(
-						"data.heroku_app.foobar", "region", "us"),
+						"data.heroku_space.foobar", "region", "virginia"),
 				),
 			},
 		},
@@ -45,7 +45,7 @@ func testAccCheckHerokuSpace_basic(spaceName string, orgName string) string {
 resource "heroku_space" "foobar" {
   name         = "%s"
   organization = "%s"
-  region       = "us"
+  region       = "virginia"
 }
 `, spaceName, orgName)
 }
@@ -58,8 +58,8 @@ resource "heroku_space" "foobar" {
   region       = "us"
 }
 
-data "heroku_app" "foobar" {
-  name = "${heroku_app.foobar.name}"
+data "heroku_space" "foobar" {
+  name = "${heroku_space.foobar.name}"
 }
 `, spaceName, orgName)
 }

--- a/heroku/data_source_heroku_space_test.go
+++ b/heroku/data_source_heroku_space_test.go
@@ -55,7 +55,7 @@ func testAccCheckHerokuSpaceWithDatasource_basic(spaceName string, orgName strin
 resource "heroku_space" "foobar" {
   name         = "%s"
   organization = "%s"
-  region       = "us"
+  region       = "virginia"
 }
 
 data "heroku_space" "foobar" {

--- a/heroku/provider.go
+++ b/heroku/provider.go
@@ -39,6 +39,10 @@ func Provider() terraform.ResourceProvider {
 			"heroku_space":             resourceHerokuSpace(),
 		},
 
+		DataSourcesMap: map[string]*schema.Resource{
+			"heroku_space": dataSourceHerokuSpace(),
+		},
+
 		ConfigureFunc: providerConfigure,
 	}
 }

--- a/heroku/provider.go
+++ b/heroku/provider.go
@@ -41,7 +41,7 @@ func Provider() terraform.ResourceProvider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"heroku_space": dataSourceHerokuSpace(),
-			"heroku_app": dataSourceHerokuApp(),
+			"heroku_app":   dataSourceHerokuApp(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/website/docs/d/space.html.markdown
+++ b/website/docs/d/space.html.markdown
@@ -1,0 +1,41 @@
+---
+layout: "heroku"
+page_title: "Heroku: heroku_space"
+sidebar_current: "docs-heroku-datasource-space-x"
+description: |-
+  Get information on a Heroku Private Space.
+---
+
+# Data Source: heroku_space
+
+Use this data source to get information about a [Heroku Private Space](https://www.heroku.com/private-spaces).
+
+## Example Usage
+
+```hcl
+# Look up a Heroku Private Space
+data "heroku_app" "default"
+  name   = "my-secret-space"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Heroku Private Space.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name` - The name of the Heroku Private Space. In Heroku, this is also the unique .
+* `id` - The unique ID of the Heroku Private Space.
+* `region` - The region in which the Heroku Private Space is deployed.
+* `state` - The state of the Heroku Private Space. Either `allocating` or `allocated`.
+* `shielded` - Whether or not the space has [Shield](https://devcenter.heroku.com/articles/private-spaces#shield-private-spaces) turned on. One of `on` or `off`.
+* `organization` - The organization that owns this app, if the app is owned by an organization. The fields for this block are documented below.
+
+The `organization` block supports:
+
+* `name` (string) - The name of the organization.

--- a/website/docs/d/space.html.markdown
+++ b/website/docs/d/space.html.markdown
@@ -14,7 +14,7 @@ Use this data source to get information about a [Heroku Private Space](https://w
 
 ```hcl
 # Look up a Heroku Private Space
-data "heroku_app" "default"
+data "heroku_space" "default"
   name   = "my-secret-space"
 }
 ```
@@ -34,7 +34,7 @@ The following attributes are exported:
 * `region` - The region in which the Heroku Private Space is deployed.
 * `state` - The state of the Heroku Private Space. Either `allocating` or `allocated`.
 * `shielded` - Whether or not the space has [Shield](https://devcenter.heroku.com/articles/private-spaces#shield-private-spaces) turned on. One of `on` or `off`.
-* `organization` - The organization that owns this app, if the app is owned by an organization. The fields for this block are documented below.
+* `organization` - The organization that owns this space, if the space is owned by an organization. The fields for this block are documented below.
 
 The `organization` block supports:
 


### PR DESCRIPTION
Inspired by the work in #41 here's a data resource for [Heroku Private Spaces](https://www.heroku.com/private-spaces).

Example HCL:

```hcl
provider "heroku" {}

data "heroku_space" "test" {
  name = "pcg-proof-of-concept"
}

output "space" {
  value = {
    state        = "${data.heroku_space.test.state}"
    shield       = "${data.heroku_space.test.shield}"
    name         = "${data.heroku_space.test.name}"
    organization = "${data.heroku_space.test.organization}"
  }
}
```

Example output: 

```
data.heroku_space.test: Refreshing state...

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

space = {
  name = my-secret-space
  organization = my-organization-name
  shield = false
  state = allocated
}
```