### PR TITLE
Document heroku_space trusted_ip_ranges, make required

### DIFF
--- a/heroku/resource_heroku_space.go
+++ b/heroku/resource_heroku_space.go
@@ -48,7 +48,7 @@ func resourceHerokuSpace() *schema.Resource {
 			"trusted_ip_ranges": {
 				Type:     schema.TypeList,
 				Computed: true,
-				Optional: true,
+				Optional: false,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},

--- a/website/docs/r/space.html.markdown
+++ b/website/docs/r/space.html.markdown
@@ -37,6 +37,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the space.
 * `organization` - (Required) The name of the organization which will own the space.
 * `region` - (Optional) The region that the space should be created in.
+* `trusted_ip_ranges` - (Required) The list of IP address CIDR ranges (0.0.0.0/0, etc) that can connect to apps hosted in this private space.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Heroku private spaces [require an IP address range of allowable addresses](https://devcenter.heroku.com/articles/private-spaces#trusted-ip-ranges). Currently the provider supports setting this, but it is not enforced or documented. This patch adds web documentation for this attribute of a `heroku_space` and makes it required, as a private space without any allowed IP address ranges is effectively useless.