### PR TITLE
WIP: Make space use an empty list for the default value of trusted_ip_ranges.

### DIFF
--- a/heroku/resource_heroku_space.go
+++ b/heroku/resource_heroku_space.go
@@ -89,26 +89,32 @@ func resourceHerokuSpaceCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error waiting for Space (%s) to become available: %s", d.Id(), err)
 	}
 
-	if ranges, ok := d.GetOk("trusted_ip_ranges"); ok {
-		var rules []*struct {
+	// If there are no ranges specified, default to empty list of ranges
+	ranges, ok := d.GetOk("trusted_ip_ranges")
+	if !ok {
+		ranges = make([]interface{}, 0)
+	}
+
+	log.Printf("[DEBUG] Setting trusted_ip_ranges")
+	var rules []*struct {
+		Action string `json:"action" url:"action,key"`
+		Source string `json:"source" url:"source,key"`
+	}
+	for _, r := range ranges.([]interface{}) {
+		log.Printf("Setting range to : %s", r.(string))
+		rules = append(rules, &struct {
 			Action string `json:"action" url:"action,key"`
 			Source string `json:"source" url:"source,key"`
-		}
-		for _, r := range ranges.([]interface{}) {
-			rules = append(rules, &struct {
-				Action string `json:"action" url:"action,key"`
-				Source string `json:"source" url:"source,key"`
-			}{
-				Action: "allow",
-				Source: r.(string),
-			})
-		}
+		}{
+			Action: "allow",
+			Source: r.(string),
+		})
+	}
 
-		opts := heroku.InboundRulesetCreateOpts{Rules: &rules}
-		_, err := client.InboundRulesetCreate(context.TODO(), space.ID, opts)
-		if err != nil {
-			return fmt.Errorf("Error creating Trusted IP Ranges for Space (%s): %s", space.ID, err)
-		}
+	ruleOpts := heroku.InboundRulesetCreateOpts{Rules: &rules}
+	_, ruleErr := client.InboundRulesetCreate(context.TODO(), space.ID, ruleOpts)
+	if ruleErr != nil {
+		return fmt.Errorf("Error creating Trusted IP Ranges for Space (%s): %s", space.ID, ruleErr)
 	}
 
 	return resourceHerokuSpaceRead(d, meta)


### PR DESCRIPTION
If trusted_ip_ranges isn't set, Heroku defaults to [0.0.0.0]. However, terraform
itself gets the value in the state set to [], resulting in a newly created space's state being
out of sync.

It is not possible (AFAICT at this point) to specify a default value for a List. Thefore,
we have no way to specify that the state should default to [0.0.0.0] that terraform can understand.

This change will break backwards compatibility - we might want to consider also making the
trusted_ip_range a required attribute, since a default of [] might be confusing to users.