### PR TITLE
Fix acceptance tests related to trusted_ip_ranges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ script:
 - make vendor-status
 - make vet
 - make website-test
-- travis_wait 120 make testacc
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ script:
 - make vendor-status
 - make vet
 - make website-test
+- make testacc
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
 - make vendor-status
 - make vet
 - make website-test
-- make testacc
+- travis_wait 120 make testacc
 
 branches:
   only:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ In order to run the full suite of Acceptance tests, run `make testacc`. You will
 Things to keep in mind when running acceptance tests:
 
 * The tests take roughly 60 minutes to run. Creating Heroku Private Spaces can take 10 minutes and the tests create/destroy a few private spaces.
-* *Acceptance tests create real resources, and often cost money to run.*
+* **Acceptance tests create real resources, and often cost money to run.**
 
 ```sh
 $ make testacc

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/terraform-providers/terraform-provider-heroku.svg?branch=master)](https://travis-ci.org/terraform-providers/terraform-provider-heroku)
+
 Terraform Provider
 ==================
 
@@ -55,9 +57,16 @@ In order to test the provider, you can simply run `make test`.
 $ make test
 ```
 
-In order to run the full suite of Acceptance tests, run `make testacc`.
+In order to run the full suite of Acceptance tests, run `make testacc`. You will need to set at least three environment variables to run them:
 
-*Note:* Acceptance tests create real resources, and often cost money to run.
+* `HEROKU_ORGANIZATION` – The organization to run the tests against.
+* `HEROKU_SPACES_ORGANIZATION` – The organization to run the Heroku Private Space tests against. 
+* `HEROKU_API_KEY` – A valid API key that has access to the two organizations listed above.
+
+Things to keep in mind when running acceptance tests:
+
+* The tests take roughly 60 minutes to run. Creating Heroku Private Spaces can take 10 minutes and the tests create/destroy a few private spaces.
+* *Acceptance tests create real resources, and often cost money to run.*
 
 ```sh
 $ make testacc

--- a/heroku/data_source_heroku_space.go
+++ b/heroku/data_source_heroku_space.go
@@ -61,7 +61,6 @@ func dataSourceHerokuSpaceRead(d *schema.ResourceData, m interface{}) error {
 	d.SetId(name)
 	d.Set("state", space.State)
 	d.Set("shield", space.Shield)
-	setSpaceAttributes(d, space)
 
-	return nil
+	return resourceHerokuSpaceRead(d, m)
 }


### PR DESCRIPTION
## What does this PR doe?

* `setSpaceAttributes` has been removed. It was only used in two places and one of them was just re-setting the already changed attribute (`name` in the case of update). I was suspicious that it was the source of the dirty plan bug and removing it did indeed fix the issue.
* Switched `trusted_ip_ranges` to `TypeSet`, which is better suited for the type of data this stores.
* Added a status badge for the `master` build in Travis.
* Added more debug logging.

## Relevant tests

**`heroku_space` data resource test**

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./heroku/ -v -run=TestAccDatasourceHerokuSpace_Basic -timeout 120m
=== RUN   TestAccDatasourceHerokuSpace_Basic
--- PASS: TestAccDatasourceHerokuSpace_Basic (447.17s)
PASS
ok      github.com/terraform-providers/terraform-provider-heroku/heroku 447.208s
```

**`heroku_space` resource tests**

Tests that the two IP ranges are set:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./heroku/ -v -run=TestAccHerokuSpace_Basic -timeout 120m
=== RUN   TestAccHerokuSpace_Basic
--- PASS: TestAccHerokuSpace_Basic (434.52s)
PASS
ok      github.com/terraform-providers/terraform-provider-heroku/heroku 434.546s
```

Tests that IP range is set to `0.0.0.0/0` by default:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./heroku/ -v -run=TestAccHerokuSpace_IPRange -timeout 120m
=== RUN   TestAccHerokuSpace_IPRange
--- PASS: TestAccHerokuSpace_IPRange (424.42s)
PASS
ok      github.com/terraform-providers/terraform-provider-heroku/heroku 424.448s
```