### PR TITLE
Add space attributes for outbound IPs and shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/terraform-providers/terraform-provider-heroku.svg?branch=master)](https://travis-ci.org/terraform-providers/terraform-provider-heroku)
+
 Terraform Provider
 ==================
 
@@ -55,9 +57,16 @@ In order to test the provider, you can simply run `make test`.
 $ make test
 ```
 
-In order to run the full suite of Acceptance tests, run `make testacc`.
+In order to run the full suite of Acceptance tests, run `make testacc`. You will need to set at least three environment variables to run them:
 
-*Note:* Acceptance tests create real resources, and often cost money to run.
+* `HEROKU_ORGANIZATION` – The organization to run the tests against.
+* `HEROKU_SPACES_ORGANIZATION` – The organization to run the Heroku Private Space tests against. 
+* `HEROKU_API_KEY` – A valid API key that has access to the two organizations listed above.
+
+Things to keep in mind when running acceptance tests:
+
+* The tests take roughly 60 minutes to run. Creating Heroku Private Spaces can take 10 minutes and the tests create/destroy a few private spaces.
+* **Acceptance tests create real resources and cost money to run. You are responsible for any costs incurred!**
 
 ```sh
 $ make testacc

--- a/heroku/data_source_heroku_space.go
+++ b/heroku/data_source_heroku_space.go
@@ -19,6 +19,15 @@ func dataSourceHerokuSpace() *schema.Resource {
 				Computed: true,
 			},
 
+			"outbound_ips": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
 			"region": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -61,7 +70,6 @@ func dataSourceHerokuSpaceRead(d *schema.ResourceData, m interface{}) error {
 	d.SetId(name)
 	d.Set("state", space.State)
 	d.Set("shield", space.Shield)
-	setSpaceAttributes(d, space)
 
-	return nil
+	return resourceHerokuSpaceRead(d, m)
 }

--- a/heroku/data_source_heroku_space.go
+++ b/heroku/data_source_heroku_space.go
@@ -22,7 +22,6 @@ func dataSourceHerokuSpace() *schema.Resource {
 			"outbound_ips": {
 				Type:     schema.TypeList,
 				Computed: true,
-				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},

--- a/website/docs/d/space.html.markdown
+++ b/website/docs/d/space.html.markdown
@@ -33,8 +33,9 @@ The following attributes are exported:
 * `id` - The unique ID of the Heroku Private Space.
 * `region` - The region in which the Heroku Private Space is deployed.
 * `state` - The state of the Heroku Private Space. Either `allocating` or `allocated`.
-* `shielded` - Whether or not the space has [Shield](https://devcenter.heroku.com/articles/private-spaces#shield-private-spaces) turned on. One of `on` or `off`.
+* `shield` - Whether or not the space has [Shield](https://devcenter.heroku.com/articles/private-spaces#shield-private-spaces) turned on. One of `on` or `off`.
 * `organization` - The organization that owns this space, if the space is owned by an organization. The fields for this block are documented below.
+* `outbound_ips` - The space's stable outbound [NAT IPs](https://devcenter.heroku.com/articles/platform-api-reference#space-network-address-translation).
 
 The `organization` block supports:
 

--- a/website/docs/r/space.html.markdown
+++ b/website/docs/r/space.html.markdown
@@ -37,6 +37,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the space.
 * `organization` - (Required) The name of the organization which will own the space.
 * `region` - (Optional) The region that the space should be created in.
+* `shield` - (Optional) Whether or not the private space should be [shielded](https://devcenter.heroku.com/articles/private-spaces#shield-private-spaces).
 
 ## Attributes Reference
 
@@ -46,6 +47,7 @@ The following attributes are exported:
 * `name` - The space's name.
 * `organization` - The space's organization.
 * `region` - The space's region.
+* `outbound_ips` - The space's stable outbound [NAT IPs](https://devcenter.heroku.com/articles/platform-api-reference#space-network-address-translation).
 
 ## Import
 


### PR DESCRIPTION
This brings together #44 and #46 with docs and tests. I also merged in #61 so I could run tests cleanly. You can see a cleaner comparison [here](https://github.com/terraform-providers/terraform-provider-heroku/compare/jstump-run-acceptance-tests...jstump-space-attributes) until #61 is merged into `master`.

* Adds `shield` attribute to `heroku_space` so people can create shielded private spaces.
* Adds `outbound_ips` attribute to `heroku_space` resource/data resource.

Test output:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./heroku/ -v -run=HerokuSpace -timeout 120m
=== RUN   TestAccDatasourceHerokuSpacePeeringInfo_Basic
--- PASS: TestAccDatasourceHerokuSpacePeeringInfo_Basic (426.58s)
=== RUN   TestAccDatasourceHerokuSpace_Basic
--- PASS: TestAccDatasourceHerokuSpace_Basic (434.23s)
=== RUN   TestAccHerokuSpace_Basic
--- PASS: TestAccHerokuSpace_Basic (416.18s)
=== RUN   TestAccHerokuSpace_Shield
--- PASS: TestAccHerokuSpace_Shield (445.95s)
=== RUN   TestAccHerokuSpace_IPRange
--- PASS: TestAccHerokuSpace_IPRange (423.53s)
PASS
ok      github.com/terraform-providers/terraform-provider-heroku/heroku 2146.509s
```