### PR TITLE
client: allow additional headers to be used

### DIFF
--- a/heroku/config.go
+++ b/heroku/config.go
@@ -4,12 +4,13 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/cyberdelia/heroku-go/v3"
+	heroku "github.com/cyberdelia/heroku-go/v3"
 )
 
 type Config struct {
-	Email  string
-	APIKey string
+	Email   string
+	APIKey  string
+	Headers http.Header
 }
 
 // Client() returns a new Service for accessing Heroku.
@@ -17,9 +18,10 @@ type Config struct {
 func (c *Config) Client() (*heroku.Service, error) {
 	service := heroku.NewService(&http.Client{
 		Transport: &heroku.Transport{
-			Username:  c.Email,
-			Password:  c.APIKey,
-			UserAgent: heroku.DefaultUserAgent,
+			Username:          c.Email,
+			Password:          c.APIKey,
+			UserAgent:         heroku.DefaultUserAgent,
+			AdditionalHeaders: c.Headers,
 		},
 	})
 

--- a/heroku/provider_test.go
+++ b/heroku/provider_test.go
@@ -1,9 +1,13 @@
 package heroku
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
+	heroku "github.com/cyberdelia/heroku-go/v3"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -26,6 +30,34 @@ func TestProvider(t *testing.T) {
 
 func TestProvider_impl(t *testing.T) {
 	var _ terraform.ResourceProvider = Provider()
+}
+
+func TestProviderConfigureUsesHeadersForClient(t *testing.T) {
+	p := Provider().(*schema.Provider)
+	d := schema.TestResourceDataRaw(t, p.Schema, nil)
+	d.Set("headers", `{"X-Custom-Header":"yes"}`)
+
+	client, err := providerConfigure(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Custom-Header"); got != "yes" {
+			t.Errorf("got X-Custom-Header: %q, want `yes`", got)
+		}
+
+		w.Write([]byte(`{"name":"some-app"}`))
+	}))
+	defer srv.Close()
+
+	c := client.(*heroku.Service)
+	c.URL = srv.URL
+
+	_, err = c.AppInfo(context.Background(), "does-not-matter")
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func testAccPreCheck(t *testing.T) {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -37,4 +37,5 @@ The following arguments are supported:
   be sourced from the `HEROKU_API_KEY` environment variable.
 * `email` - (Required) Email to be notified by Heroku. It must be provided, but
   it can also be sourced from the `HEROKU_EMAIL` environment variable.
-
+* `headers` - (Optional) Additional Headers to be sent to Heroku. If not provided,
+  it can also be sourced from the `HEROKU_HEADERS` environment variable.


### PR DESCRIPTION
## Context

In certain cases, some special headers are required to complete certain actions. These headers should be opaque, and can be defined on `HEROKU_HEADERS`.

The heroku CLI already does this for us, and sets a JSON payload, so we have to unmarshal them into a map.