### PR TITLE
WIP: Migrate from deprecated organizations to teams

### DIFF
--- a/heroku/data_source_heroku_app.go
+++ b/heroku/data_source_heroku_app.go
@@ -68,8 +68,10 @@ func dataSourceHerokuApp() *schema.Resource {
 			},
 
 			"organization": {
-				Type:     schema.TypeList,
-				Computed: true,
+				Type:          schema.TypeMap,
+				Computed:      true,
+				ConflictsWith: []string{"team"},
+				Deprecated:    "Heroku has deprecated organizations. Use team instead.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
@@ -85,6 +87,32 @@ func dataSourceHerokuApp() *schema.Resource {
 						"personal": {
 							Type:     schema.TypeBool,
 							Computed: true,
+						},
+					},
+				},
+			},
+
+			"team": {
+				Type:          schema.TypeMap,
+				Computed:      true,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"organization"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"locked": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+
+						"personal": {
+							Type:     schema.TypeBool,
+							Optional: true,
 						},
 					},
 				},

--- a/heroku/data_source_heroku_app.go
+++ b/heroku/data_source_heroku_app.go
@@ -104,8 +104,8 @@ func dataSourceHerokuAppRead(d *schema.ResourceData, m interface{}) error {
 
 	d.SetId(time.Now().UTC().String())
 
-	if app.Organization {
-		err := setOrganizationDetails(d, app)
+	if app.Team {
+		err := setTeamDetails(d, app)
 		if err != nil {
 			return err
 		}

--- a/heroku/resource_heroku_app.go
+++ b/heroku/resource_heroku_app.go
@@ -172,7 +172,7 @@ func resourceHerokuApp() *schema.Resource {
 			},
 
 			"organization": {
-				Type:          schema.TypeList,
+				Type:          schema.TypeMap,
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"team"},
@@ -199,7 +199,7 @@ func resourceHerokuApp() *schema.Resource {
 			},
 
 			"team": {
-				Type:          schema.TypeList,
+				Type:          schema.TypeMap,
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"organization"},
@@ -400,7 +400,16 @@ func setTeamDetails(d *schema.ResourceData, app *application) (err error) {
 	}
 
 	err = d.Set("team", []interface{}{teamDetails})
-	return err
+	if err != nil {
+		return err
+	}
+
+	// @joestump 07/06/2018 Set both team and organization attributes for
+	// backwards compatibility.
+	err = d.Set("organization", []interface{}{teamDetails})
+	if err != nil {
+		return err
+	}
 }
 
 func setAppDetails(d *schema.ResourceData, app *application) (err error) {


### PR DESCRIPTION
Heroku has [deprecated organizations](https://devcenter.heroku.com/changelog-items/1132) in favor of teams. Heroku Private Spaces are only supported on "team apps". Because `ForceNew: true` is set on the `organization` attribute, and there are two separate API endpoints/code paths, this PR is introducing a preference for the `team` attribute while falling back to `organization`.

People using the provider wishing to use `team` instead of `organization` would need to do state manipulations to port existing `heroku_app` resources over.