### PR TITLE
Improve debugging by dumping http request/responses

### DIFF
--- a/heroku/config.go
+++ b/heroku/config.go
@@ -3,6 +3,7 @@ package heroku
 import (
 	"log"
 	"net/http"
+	"os"
 
 	heroku "github.com/cyberdelia/heroku-go/v3"
 )
@@ -13,15 +14,19 @@ type Config struct {
 	Headers http.Header
 }
 
-// Client() returns a new Service for accessing Heroku.
-//
+// Client returns a new Service for accessing Heroku.
 func (c *Config) Client() (*heroku.Service, error) {
+	var debugHTTP = false
+	if os.Getenv("TF_LOG") == "TRACE" || os.Getenv("TF_LOG") == "DEBUG" {
+		debugHTTP = true
+	}
 	service := heroku.NewService(&http.Client{
 		Transport: &heroku.Transport{
 			Username:          c.Email,
 			Password:          c.APIKey,
 			UserAgent:         heroku.DefaultUserAgent,
 			AdditionalHeaders: c.Headers,
+			Debug:             debugHTTP,
 		},
 	})
 

--- a/vendor/github.com/cyberdelia/heroku-go/v3/transport.go
+++ b/vendor/github.com/cyberdelia/heroku-go/v3/transport.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net/http"
 	"net/http/httputil"
-	"os"
 	"strings"
 
 	"github.com/pborman/uuid"
@@ -80,8 +79,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		if err != nil {
 			log.Println(err)
 		} else {
-			os.Stderr.Write(dump)
-			os.Stderr.Write([]byte{'\n', '\n'})
+			log.Printf("%s", dump)
 		}
 	}
 
@@ -98,8 +96,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		if err != nil {
 			log.Println(err)
 		} else {
-			os.Stderr.Write(dump)
-			os.Stderr.Write([]byte{'\n'})
+			log.Printf("%s", dump)
 		}
 	}
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -227,10 +227,10 @@
 			"revisionTime": "2017-07-27T06:48:18Z"
 		},
 		{
-			"checksumSHA1": "R4SodIvhGFxRKNh9ulaFPFj53kk=",
+			"checksumSHA1": "qb+SpSx+zdt3nvGrROYdonUWDIc=",
 			"path": "github.com/cyberdelia/heroku-go/v3",
-			"revision": "672b736f0b4e86292b57e4c8ecfd60d7a3d9b1a9",
-			"revisionTime": "2018-05-31T22:59:59Z"
+			"revision": "7d6f324fc6283f685c815221e5b8262ae60bb6fc",
+			"revisionTime": "2018-07-04T20:17:23Z"
 		},
 		{
 			"checksumSHA1": "dvabztWVQX8f6oMLRyv4dLH+TGY=",


### PR DESCRIPTION
When `TF_LOG` is set to `DEBUG` or `TRACE` HTTP request/responses are logged.

This requires a bump `heroku-go` to cyberdelia/heroku-go@7d6f324fc6283f685c815221e5b8262ae60bb6fc which pulls in a related logging improvement cyberdelia/heroku-go#28

Warning: this does log all headers including sensitive ones like `Authorization:` 

Example output:
```
2018-07-08T20:05:28.412-0400 [DEBUG] plugin.terraform-provider-heroku: 2018/07/08 20:05:28 GET /spaces/bf8bf6a4-89f3-4aff-9504-97767fd8d81a/nat HTTP/1.1
2018-07-08T20:05:28.412-0400 [DEBUG] plugin.terraform-provider-heroku: Host: api.heroku.com
2018-07-08T20:05:28.412-0400 [DEBUG] plugin.terraform-provider-heroku: User-Agent: heroku/v3 (darwin; amd64)
2018-07-08T20:05:28.412-0400 [DEBUG] plugin.terraform-provider-heroku: Accept: application/vnd.heroku+json; version=3
2018-07-08T20:05:28.412-0400 [DEBUG] plugin.terraform-provider-heroku: Authorization: Basic xxx
2018-07-08T20:05:28.412-0400 [DEBUG] plugin.terraform-provider-heroku: Request-Id: 1c4c997b-6ab1-496d-a12d-c2ad86398cc7
2018-07-08T20:05:28.412-0400 [DEBUG] plugin.terraform-provider-heroku: Accept-Encoding: gzip
2018-07-08T20:05:28.412-0400 [DEBUG] plugin.terraform-provider-heroku:
2018-07-08T20:05:28.418-0400 [DEBUG] plugin.terraform-provider-heroku: 2018/07/08 20:05:28 HTTP/1.1 200 OK
2018-07-08T20:05:28.418-0400 [DEBUG] plugin.terraform-provider-heroku: Cache-Control: private, no-cache
2018-07-08T20:05:28.418-0400 [DEBUG] plugin.terraform-provider-heroku: Content-Expansion: region
2018-07-08T20:05:28.418-0400 [DEBUG] plugin.terraform-provider-heroku: Content-Type: application/json
2018-07-08T20:05:28.418-0400 [DEBUG] plugin.terraform-provider-heroku: Date: Mon, 09 Jul 2018 00:05:28 GMT
2018-07-08T20:05:28.418-0400 [DEBUG] plugin.terraform-provider-heroku: Etag: "b9e8d4deec7af251d3e28e9db0f729d6"
2018-07-08T20:05:28.418-0400 [DEBUG] plugin.terraform-provider-heroku: Last-Modified: Thu, 07 Jun 2018 18:46:38 GMT
2018-07-08T20:05:28.418-0400 [DEBUG] plugin.terraform-provider-heroku: Oauth-Scope: global platform
2018-07-08T20:05:28.418-0400 [DEBUG] plugin.terraform-provider-heroku: Oauth-Scope-Accepted: global read read-protected write write-protected
2018-07-08T20:05:28.418-0400 [DEBUG] plugin.terraform-provider-heroku: Ratelimit-Multiplier: 1
2018-07-08T20:05:28.418-0400 [DEBUG] plugin.terraform-provider-heroku: Ratelimit-Remaining: 4493
2018-07-08T20:05:28.418-0400 [DEBUG] plugin.terraform-provider-heroku: Request-Id: a9181d61-7694-4a70-8fe7-a11107a7bc5d,4661a15f-e2f6-49bf-9466-7f359754033b,78e37360-d880-2d5e-af1a-da1ceff8f8ed,83ee8c24-4821-b5e3-81a1-f90acf7dcb45
2018-07-08T20:05:28.418-0400 [DEBUG] plugin.terraform-provider-heroku: Vary: Accept-Encoding
2018-07-08T20:05:28.418-0400 [DEBUG] plugin.terraform-provider-heroku: Via: 1.1 spaces-router (30e8f6919785), 1.1 spaces-router (30e8f6919785)
2018-07-08T20:05:28.418-0400 [DEBUG] plugin.terraform-provider-heroku: X-Content-Type-Options: nosniff
2018-07-08T20:05:28.418-0400 [DEBUG] plugin.terraform-provider-heroku: X-Runtime: 0.070774494
2018-07-08T20:05:28.418-0400 [DEBUG] plugin.terraform-provider-heroku:
```