### PR TITLE
Add a heroku_space_inbound_ruleset resources for managing inbound CIDR blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.3 (Unreleased)
+## 1.1.0 (Unreleased)
 
 FEATURES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.0.3 (Unreleased)
+
+FEATURES:
+
+* r/heroku_space_inbound_ruleset: Add a new resource for managing [inbound IP rulesets](https://devcenter.heroku.com/articles/platform-api-reference#inbound-ruleset) for Heroku Private Spaces ([#91](https://github.com/terraform-providers/terraform-provider-heroku/pull/91))
+
 ## 1.0.2 (July 10, 2018)
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ FEATURES:
 
 * r/heroku_space_inbound_ruleset: Add a new resource for managing [inbound IP rulesets](https://devcenter.heroku.com/articles/platform-api-reference#inbound-ruleset) for Heroku Private Spaces ([#91](https://github.com/terraform-providers/terraform-provider-heroku/pull/91))
 
+IMPROVEMENTS:
+
+* HTTP headers are now shown when `TF_LOG` is set to `DEBUG` or `TRACE` [#89](https://github.com/terraform-providers/terraform-provider-heroku/pull/89)
+
 ## 1.0.2 (July 10, 2018)
 
 BUG FIXES:

--- a/heroku/provider.go
+++ b/heroku/provider.go
@@ -46,6 +46,7 @@ func Provider() terraform.ResourceProvider {
 			"heroku_pipeline":                          resourceHerokuPipeline(),
 			"heroku_pipeline_coupling":                 resourceHerokuPipelineCoupling(),
 			"heroku_space":                             resourceHerokuSpace(),
+			"heroku_space_inbound_ruleset":             resourceHerokuSpaceInboundRuleset(),
 			"heroku_space_peering_connection_accepter": resourceHerokuSpacePeeringConnectionAccepter(),
 			"heroku_team_collaborator":                 resourceHerokuTeamCollaborator(),
 		},

--- a/heroku/resource_heroku_space.go
+++ b/heroku/resource_heroku_space.go
@@ -62,10 +62,11 @@ func resourceHerokuSpace() *schema.Resource {
 			},
 
 			"trusted_ip_ranges": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Optional: true,
-				MinItems: 0,
+				Type:       schema.TypeSet,
+				Computed:   true,
+				Optional:   true,
+				MinItems:   0,
+				Deprecated: "This attribute is deprecated in favor of heroku_space_inbound_ruleset. Using both at the same time will likely cause unexpected behavior.",
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},

--- a/heroku/resource_heroku_space_inbound_ruleset.go
+++ b/heroku/resource_heroku_space_inbound_ruleset.go
@@ -23,7 +23,7 @@ func resourceHerokuSpaceInboundRuleset() *schema.Resource {
 			},
 
 			"rule": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Required: true,
 				MinItems: 1,
 				Elem: &schema.Resource{
@@ -98,6 +98,7 @@ func resourceHerokuSpaceInboundRulesetRead(d *schema.ResourceData, meta interfac
 		rulesList = append(rulesList, values)
 	}
 
+	d.SetId(ruleset.ID)
 	d.Set("rule", rulesList)
 
 	return nil

--- a/heroku/resource_heroku_space_inbound_ruleset.go
+++ b/heroku/resource_heroku_space_inbound_ruleset.go
@@ -1,0 +1,140 @@
+package heroku
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	heroku "github.com/cyberdelia/heroku-go/v3"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/validators"
+)
+
+type spacePeerInfo struct {
+	heroku.Peering
+}
+
+func resourceHerokuSpaceInboundRuleset() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceHerokuSpaceInboundRulesetSet,
+		Read:   resourceHerokuSpaceInboundRulesetRead,
+		Update: resourceHerokuSpaceInboundRulesetSet,
+		Delete: resourceHerokuSpaceInboundRulesetDelete,
+
+		Schema: map[string]*schema.Schema{
+			"space": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"rule": {
+				Type:     schema.TypeList,
+				Required: true,
+				MinItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"action": {
+							Type:     schema.TypeString,
+							Required: true,
+							Default:  codebuild.CacheTypeNoCache,
+							ValidateFunc: validation.StringInSlice([]string{
+								"allow",
+								"deny",
+							}, false),
+						},
+						"source": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateCIDRNetworkAddress,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func getRulesetFromSchema(d *schema.ResourceData) heroku.InboundRulesetCreateOpts {
+	rules := d.Get("rule").(*schema.Set)
+
+	var ruleset []*struct {
+		Action string `json:"action" url:"action,key"`
+		Source string `json:"source" url:"source,key"`
+	}
+
+	for _, r := range rules.List() {
+		data := config.(map[string]interface{})
+
+		ruleset = append(ruleset, &struct {
+			Action string `json:"action" url:"action,key"`
+			Source string `json:"source" url:"source,key"`
+		}{
+			Action: data["action"].(string),
+			Source: data["source"].(string),
+		})
+	}
+
+	return heroku.InboundRulesetCreateOpts{Rules: rules}
+}
+
+func resourceHerokuSpaceInboundRulesetSet(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*heroku.Service)
+
+	spaceIdentity := d.Get("space").(string)
+	ruleset := getRulesetFromSchema(d)
+
+	_, err := client.InboundRulesetCreate(context.TODO(), spaceIdentity, ruleset)
+	if err != nil {
+		return fmt.Errorf("Error creating inbound ruleset for space (%s): %s", space.ID, err)
+	}
+
+	return resourceHerokuSpaceInboundRulesetRead(d, meta)
+}
+
+func resourceHerokuSpaceInboundRulesetRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*heroku.Service)
+
+	spaceIdentity := d.Get("space").(string)
+	ruleset, err := client.InboundRulesetCurrent(context.TODO(), spaceIdentity)
+	if err != nil {
+		return fmt.Errorf("Error creating inbound ruleset for space (%s): %s", space.ID, err)
+	}
+
+	rulesList := []interface{}{}
+	for rule := range ruleset.Rules {
+		values := map[string]interface{}{}
+		values["source"] = rule.Source
+		values["action"] = rule.Action
+		rulesList = append(rulesList, values)
+	}
+
+	d.Set("rule", rulesList)
+
+	return nil
+}
+
+func resourceHerokuSpaceInboundRulesetDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*heroku.Service)
+
+	ruleset := &heroku.InboundRulesetCreateOpts{
+		Rules: []*struct {
+			Action string
+			Source string
+		}{
+			Action: "allow",
+			Source: "0.0.0.0/0",
+		},
+	}
+
+	_, err := client.InboundRulesetCreate(context.TODO(), spaceIdentity, ruleset)
+	if err != nil {
+		return fmt.Errorf("Error resettting inbound ruleset for space (%s): %s", space.ID, err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/heroku/resource_heroku_space_inbound_ruleset.go
+++ b/heroku/resource_heroku_space_inbound_ruleset.go
@@ -100,6 +100,7 @@ func resourceHerokuSpaceInboundRulesetRead(d *schema.ResourceData, meta interfac
 
 	d.SetId(ruleset.ID)
 	d.Set("rule", rulesList)
+	d.Set("space", ruleset.Space.Name)
 
 	return nil
 }
@@ -128,7 +129,7 @@ func resourceHerokuSpaceInboundRulesetDelete(d *schema.ResourceData, meta interf
 
 	_, err := client.InboundRulesetCreate(context.TODO(), spaceIdentity, heroku.InboundRulesetCreateOpts{Rules: rules})
 	if err != nil {
-		return fmt.Errorf("Error resettting inbound ruleset for space (%s): %s", spaceIdentity, err)
+		return fmt.Errorf("Error resetting inbound ruleset for space (%s): %s", spaceIdentity, err)
 	}
 
 	d.SetId("")

--- a/heroku/resource_heroku_space_inbound_ruleset.go
+++ b/heroku/resource_heroku_space_inbound_ruleset.go
@@ -109,6 +109,10 @@ func resourceHerokuSpaceInboundRulesetDelete(d *schema.ResourceData, meta interf
 
 	spaceIdentity := d.Get("space").(string)
 
+	// Heroku Private Spaces ship with a default 0.0.0.0/0 inbound ruleset. An HPS *MUST* have
+	// an inbound ruleset. There's no delete API method for this. So when we "delete" the ruleset
+	// we reset things back to what Heroku sets when the HPS is created. Given that the default
+	// allows all traffic from all places, this is akin to deleting all filtering.
 	var rules []*struct {
 		Action string `json:"action" url:"action,key"`
 		Source string `json:"source" url:"source,key"`

--- a/heroku/resource_heroku_space_inbound_ruleset_test.go
+++ b/heroku/resource_heroku_space_inbound_ruleset_test.go
@@ -1,14 +1,12 @@
 package heroku
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
 	heroku "github.com/cyberdelia/heroku-go/v3"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccHerokuSpaceInboundRuleset_Basic(t *testing.T) {
@@ -33,14 +31,6 @@ func TestAccHerokuSpaceInboundRuleset_Basic(t *testing.T) {
 					testAccCheckHerokuSpaceExists("heroku_space.foobar", &space),
 					resource.TestCheckResourceAttr(
 						"heroku_space_inbound_ruleset.foobar", "rule.#", "2"),
-					resource.TestCheckResourceAttr(
-						"heroku_space_inbound_ruleset.foobar", "rule.1.action", "allow"),
-					resource.TestCheckResourceAttr(
-						"heroku_space_inbound_ruleset.foobar", "rule.1.source", "8.8.8.8/32"),
-					resource.TestCheckResourceAttr(
-						"heroku_space_inbound_ruleset.foobar", "rule.2.action", "allow"),
-					resource.TestCheckResourceAttr(
-						"heroku_space_inbound_ruleset.foobar", "rule.2.source", "8.8.8.0/24"),
 				),
 			},
 		},
@@ -56,44 +46,17 @@ resource "heroku_space" "foobar" {
 }
 
 resource "heroku_space_inbound_ruleset" "foobar" {
-    space = "${heroku_space.foobar.name}
+  space = "${heroku_space.foobar.name}"
 
-	rule { 
-        action = "allow"
-        source = "8.8.8.8/32"
-    }
+  rule { 
+    action = "allow"
+    source = "8.8.8.8/32"
+  }
 
-	rule { 
-        action = "allow"
-        source = "8.8.8.0/24"
-    }
+  rule {
+    action = "allow"
+    source = "8.8.8.0/24"
+  }
 }
 `, spaceName, orgName)
-}
-
-func testAccCheckHerokuSpaceInboundRulesetIsSet(n string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No space name set")
-		}
-
-		client := testAccProvider.Meta().(*heroku.Service)
-
-		foundSpace, err := client.SpaceInfo(context.TODO(), rs.Primary.ID)
-		if err != nil {
-			return err
-		}
-
-		if foundSpace.ID != rs.Primary.ID {
-			return fmt.Errorf("Space not found")
-		}
-
-		return nil
-	}
 }

--- a/heroku/resource_heroku_space_inbound_ruleset_test.go
+++ b/heroku/resource_heroku_space_inbound_ruleset_test.go
@@ -1,0 +1,100 @@
+package heroku
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	heroku "github.com/cyberdelia/heroku-go/v3"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccHerokuSpaceInboundRuleset_Basic(t *testing.T) {
+	var space heroku.Space
+	spaceName := fmt.Sprintf("tftest1-%s", acctest.RandString(10))
+	org := getTestingOrgName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			if org == "" {
+				t.Skip("HEROKU_ORGANIZATION is not set; skipping test.")
+			}
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHerokuSpaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				ResourceName: "heroku_space_inbound_ruleset.foobar",
+				Config:       testAccCheckHerokuSpaceInboundRulesetConfig_basic(spaceName, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHerokuSpaceExists("heroku_space.foobar", &space),
+					resource.TestCheckResourceAttr(
+						"heroku_space_inbound_ruleset.foobar", "rule.#", "2"),
+					resource.TestCheckResourceAttr(
+						"heroku_space_inbound_ruleset.foobar", "rule.1.action", "allow"),
+					resource.TestCheckResourceAttr(
+						"heroku_space_inbound_ruleset.foobar", "rule.1.source", "8.8.8.8/32"),
+					resource.TestCheckResourceAttr(
+						"heroku_space_inbound_ruleset.foobar", "rule.2.action", "allow"),
+					resource.TestCheckResourceAttr(
+						"heroku_space_inbound_ruleset.foobar", "rule.2.source", "8.8.8.0/24"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckHerokuSpaceInboundRulesetConfig_basic(spaceName, orgName string) string {
+	return fmt.Sprintf(`
+resource "heroku_space" "foobar" {
+  name         = "%s"
+  organization = "%s"
+  region       = "virginia"
+}
+
+resource "heroku_space_inbound_ruleset" "foobar" {
+    space = "${heroku_space.foobar.name}
+
+	rule { 
+        action = "allow"
+        source = "8.8.8.8/32"
+    }
+
+	rule { 
+        action = "allow"
+        source = "8.8.8.0/24"
+    }
+}
+`, spaceName, orgName)
+}
+
+func testAccCheckHerokuSpaceInboundRulesetIsSet(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No space name set")
+		}
+
+		client := testAccProvider.Meta().(*heroku.Service)
+
+		foundSpace, err := client.SpaceInfo(context.TODO(), rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if foundSpace.ID != rs.Primary.ID {
+			return fmt.Errorf("Space not found")
+		}
+
+		return nil
+	}
+}

--- a/heroku/resource_heroku_space_inbound_ruleset_test.go
+++ b/heroku/resource_heroku_space_inbound_ruleset_test.go
@@ -3,7 +3,6 @@ package heroku
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	heroku "github.com/cyberdelia/heroku-go/v3"

--- a/heroku/validators.go
+++ b/heroku/validators.go
@@ -2,6 +2,7 @@ package heroku
 
 import (
 	"fmt"
+	"net"
 	"strings"
 
 	"github.com/satori/uuid"
@@ -34,5 +35,24 @@ func validateUUID(v interface{}, k string) (ws []string, errors []error) {
 	if _, err := uuid.FromString(v.(string)); err != nil {
 		errors = append(errors, fmt.Errorf("%q is an invalid UUID: %s", k, err))
 	}
+	return
+}
+
+// validateCIDRNetworkAddress ensures that the string value is a valid CIDR that
+// represents a network address - it adds an error otherwise
+func validateCIDRNetworkAddress(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	_, ipnet, err := net.ParseCIDR(value)
+	if err != nil {
+		errors = append(errors, fmt.Errorf(
+			"%q must contain a valid CIDR, got error parsing: %s", k, err))
+		return
+	}
+
+	if ipnet == nil || value != ipnet.String() {
+		errors = append(errors, fmt.Errorf(
+			"%q must contain a valid network CIDR, got %q", k, value))
+	}
+
 	return
 }

--- a/website/docs/r/space_inbound_ruleset.html.markdown
+++ b/website/docs/r/space_inbound_ruleset.html.markdown
@@ -1,0 +1,55 @@
+---
+layout: "heroku"
+page_title: "Heroku: heroku_space_inbound_ruleset"
+sidebar_current: "docs-heroku-resource-space-inbound-ruleset"
+description: |-
+  Provides a resource for managing inbound rulesets for Heroku Private Spaces.
+---
+
+# heroku\_space\_inbound\_ruleset
+
+Provides a resource for managing [inbound rulesets](https://devcenter.heroku.com/articles/platform-api-reference#inbound-ruleset) for Heroku Private Spaces.
+
+## Example Usage
+
+```hcl
+# Create a new Heroku space
+resource "heroku_space" "default" {
+  name         = "test-space"
+  organization = "my-company"
+  region       = "virginia"
+}
+
+# Allow all traffic EXCEPT 8.8.4.4 to access the HPS.
+resource "heroku_space_inbound_ruleset" "default" {
+  space = "${heroku_space.default.name}"
+
+  rule {
+    action = "allow"
+    source = "0.0.0.0/0"
+  }
+
+  rule {
+    action = "deny"
+    source = "8.8.4.4/32"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `space` - (Required) The name of the space.
+* `rule` - (Required) At least one `rule` block. Rules are documented below.
+
+A `rule` block supports the following arguments:
+
+* `action` - (Required) The action to apply this rule to. Must be one of `allow` or `deny`.
+* `source` - (Required) A CIDR block source for the rule.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the inbound ruleset.

--- a/website/heroku.erb
+++ b/website/heroku.erb
@@ -75,6 +75,10 @@
                       <a href="/docs/providers/heroku/r/space.html">heroku_space</a>
                     </li>
 
+                    <li<%= sidebar_current("docs-heroku-resource-space-inbound-ruleset") %>>
+                      <a href="/docs/providers/heroku/r/space_inbound_ruleset.html">heroku_space_inbound_ruleset</a>
+                    </li>
+
                     <li<%= sidebar_current("docs-heroku-resource-space-peering-connection-accepter") %>>
                       <a href="/docs/providers/heroku/r/space_peering_connection_accepter.html">heroku_space_peering_connection_accepter</a>
                     </li>


### PR DESCRIPTION
Introduces a new resource called `heroku_space_inbound_ruleset` that allows you to manage [inbound rulesets](https://devcenter.heroku.com/articles/platform-api-reference#inbound-ruleset-create) for a Heroku Private Space.

One of the oddities of this resource is that you can't delete a space's ruleset. It's like a singleton that defaults to `0.0.0.0/0`. I set it back to `0.0.0.0/0` when you "delete" the ruleset.

```hcl
provider "heroku" {}

resource "heroku_space" "foobar" {
  name         = "joe-testing-1"
  organization = "some-org-here"
  region       = "virginia"
}

resource "heroku_space_inbound_ruleset" "foobar" {
  space = "${heroku_space.foobar.name}"

  rule {
    action = "allow"
    source = "8.8.8.8/32"
  }

  rule {
    action = "allow"
    source = "8.8.8.0/24"
  }
}
```