### PR TITLE
Add `internal_routing` option to `heroku_app`

### DIFF
--- a/heroku/data_source_heroku_app.go
+++ b/heroku/data_source_heroku_app.go
@@ -34,6 +34,11 @@ func dataSourceHerokuApp() *schema.Resource {
 				Default:  nil,
 			},
 
+			"internal_routing": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
 			"buildpacks": {
 				Type:     schema.TypeList,
 				Computed: true,

--- a/heroku/provider_test.go
+++ b/heroku/provider_test.go
@@ -61,10 +61,6 @@ func TestProviderConfigureUsesHeadersForClient(t *testing.T) {
 }
 
 func testAccPreCheck(t *testing.T) {
-	if v := os.Getenv("HEROKU_EMAIL"); v == "" {
-		t.Fatal("HEROKU_EMAIL must be set for acceptance tests")
-	}
-
 	if v := os.Getenv("HEROKU_API_KEY"); v == "" {
 		t.Fatal("HEROKU_API_KEY must be set for acceptance tests")
 	}

--- a/heroku/resource_heroku_app_test.go
+++ b/heroku/resource_heroku_app_test.go
@@ -269,7 +269,7 @@ func TestAccHerokuApp_Organization(t *testing.T) {
 				Config: testAccCheckHerokuAppConfig_organization(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAppExistsOrg("heroku_app.foobar", &app),
-					testAccCheckHerokuAppAttributesOrg(&app, appName, "", org),
+					testAccCheckHerokuAppAttributesOrg(&app, appName, "", org, false),
 				),
 			},
 		},
@@ -296,7 +296,34 @@ func TestAccHerokuApp_Space(t *testing.T) {
 				Config: testAccCheckHerokuAppConfig_space(appName, spaceName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAppExistsOrg("heroku_app.foobar", &app),
-					testAccCheckHerokuAppAttributesOrg(&app, appName, spaceName, org),
+					testAccCheckHerokuAppAttributesOrg(&app, appName, spaceName, org, false),
+				),
+			},
+		},
+	})
+}
+
+func TestAccHerokuApp_Space_Internal(t *testing.T) {
+	var app heroku.TeamApp
+	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := os.Getenv("HEROKU_SPACES_ORGANIZATION")
+	spaceName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			if org == "" {
+				t.Skip("HEROKU_SPACES_ORGANIZATION is not set; skipping test.")
+			}
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHerokuAppDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuAppConfig_space_internal(appName, spaceName, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHerokuAppExistsOrg("heroku_app.foobar", &app),
+					testAccCheckHerokuAppAttributesOrg(&app, appName, spaceName, org, true),
 				),
 			},
 		},
@@ -478,7 +505,7 @@ func testAccCheckHerokuAppNoBuildpacks(appName string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckHerokuAppAttributesOrg(app *heroku.TeamApp, appName, space, org string) resource.TestCheckFunc {
+func testAccCheckHerokuAppAttributesOrg(app *heroku.TeamApp, appName, space, org string, internal bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*heroku.Service)
 
@@ -505,6 +532,14 @@ func testAccCheckHerokuAppAttributesOrg(app *heroku.TeamApp, appName, space, org
 
 		if app.Team == nil || app.Team.Name != org {
 			return fmt.Errorf("Bad org: %v", app.Team)
+		}
+
+		appInternalRouting := false
+		if app.InternalRouting != nil {
+			appInternalRouting = *app.InternalRouting
+		}
+		if appInternalRouting != internal {
+			return fmt.Errorf("Bad internal routing: %v (want %v)", appInternalRouting, internal)
 		}
 
 		vars, err := client.ConfigVarInfoForApp(context.TODO(), app.Name)
@@ -695,6 +730,29 @@ resource "heroku_app" "foobar" {
   name   = "%s"
   space  = "${heroku_space.foobar.name}"
   region = "virginia"
+
+  organization {
+    name = "%s"
+  }
+
+  config_vars {
+    FOO = "bar"
+  }
+}`, spaceName, org, appName, org)
+}
+
+func testAccCheckHerokuAppConfig_space_internal(appName, spaceName, org string) string {
+	return fmt.Sprintf(`
+resource "heroku_space" "foobar" {
+  name = "%s"
+	organization = "%s"
+	region = "virginia"
+}
+resource "heroku_app" "foobar" {
+  name             = "%s"
+  space            = "${heroku_space.foobar.name}"
+  region           = "virginia"
+	internal_routing = true
 
   organization {
     name = "%s"

--- a/heroku/resource_heroku_app_test.go
+++ b/heroku/resource_heroku_app_test.go
@@ -31,6 +31,8 @@ func TestAccHerokuApp_Basic(t *testing.T) {
 						"heroku_app.foobar", "name", appName),
 					resource.TestCheckResourceAttr(
 						"heroku_app.foobar", "config_vars.0.FOO", "bar"),
+					resource.TestCheckResourceAttr(
+						"heroku_app.foobar", "internal_routing", "false"),
 				),
 			},
 		},
@@ -249,7 +251,7 @@ func TestAccHerokuApp_ACM(t *testing.T) {
 }
 
 func TestAccHerokuApp_Organization(t *testing.T) {
-	var app heroku.OrganizationApp
+	var app heroku.TeamApp
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 	org := os.Getenv("HEROKU_ORGANIZATION")
 
@@ -275,7 +277,7 @@ func TestAccHerokuApp_Organization(t *testing.T) {
 }
 
 func TestAccHerokuApp_Space(t *testing.T) {
-	var app heroku.OrganizationApp
+	var app heroku.TeamApp
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 	org := os.Getenv("HEROKU_SPACES_ORGANIZATION")
 	spaceName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
@@ -476,7 +478,7 @@ func testAccCheckHerokuAppNoBuildpacks(appName string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckHerokuAppAttributesOrg(app *heroku.OrganizationApp, appName, space, org string) resource.TestCheckFunc {
+func testAccCheckHerokuAppAttributesOrg(app *heroku.TeamApp, appName, space, org string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*heroku.Service)
 
@@ -501,8 +503,8 @@ func testAccCheckHerokuAppAttributesOrg(app *heroku.OrganizationApp, appName, sp
 			return fmt.Errorf("Bad name: %s", app.Name)
 		}
 
-		if app.Organization == nil || app.Organization.Name != org {
-			return fmt.Errorf("Bad org: %v", app.Organization)
+		if app.Team == nil || app.Team.Name != org {
+			return fmt.Errorf("Bad org: %v", app.Team)
 		}
 
 		vars, err := client.ConfigVarInfoForApp(context.TODO(), app.Name)
@@ -548,7 +550,7 @@ func testAccCheckHerokuAppExists(n string, app *heroku.App) resource.TestCheckFu
 	}
 }
 
-func testAccCheckHerokuAppExistsOrg(n string, app *heroku.OrganizationApp) resource.TestCheckFunc {
+func testAccCheckHerokuAppExistsOrg(n string, app *heroku.TeamApp) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 
@@ -562,7 +564,7 @@ func testAccCheckHerokuAppExistsOrg(n string, app *heroku.OrganizationApp) resou
 
 		client := testAccProvider.Meta().(*heroku.Service)
 
-		foundApp, err := client.OrganizationAppInfo(context.TODO(), rs.Primary.ID)
+		foundApp, err := client.TeamAppInfo(context.TODO(), rs.Primary.ID)
 
 		if err != nil {
 			return err

--- a/website/docs/r/app.html.markdown
+++ b/website/docs/r/app.html.markdown
@@ -46,6 +46,10 @@ The following arguments are supported:
      configuration variables set externally won't be removed by Terraform
      if they aren't present in this list.
 * `space` - (Optional) The name of a private space to create the app in.
+* `internal_routing` - (Optional) If true, the application will be routable
+  only internally in a private space. This option is only available for apps
+  that also specify `space`. This feature is currently only available in
+  private beta. Contact Heroku Support for more details.
 * `organization` - (Optional) A block that can be specified once to define
      organization settings for this app. The fields for this block are
      documented below.
@@ -67,6 +71,8 @@ The following attributes are exported:
 * `stack` - The application stack is what platform to run the application
    in.
 * `space` - The private space the app should run in.
+* `internal_routing` - Whether internal routing is enabled the private space
+  app.
 * `region` - The region that the app should be deployed in.
 * `git_url` - The Git URL for the application. This is used for
    deploying new versions of the app.

--- a/website/docs/r/app.html.markdown
+++ b/website/docs/r/app.html.markdown
@@ -61,6 +61,8 @@ The `organization` block supports:
 * `locked` (boolean)
 * `personal` (boolean)
 
+~> **NOTE:** Internal routing is currently a beta feature that requires you email Heroku Support to have it enabled. Without this feature enabled by Heroku Support the `internal_routing` attribute will be ignored.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
This pre-beta feature enables Heroku apps to be routable only within the private space. Specifically, the `foo.herokuapp.com` DNS name will resolve to a load balancer with an internal IP address, routable only within the private space.

While this feature is not generally available at this time, we ideally want the Terraform provider to support it at the time of launch.

I've also started transitioning the internals of `heroku_app` to use `Team`, rather than `Organization` since the term `organization` is deprecated in favor of `team`. They are functionally equivalent for most cases. However, new functionality (`internal_routing` included) is only being added to the `team` route, rather than the `organization` route to encourage the switchover. These changes shouldn't introduce any breaking changes for users of the provider though. Eventually, we might want to start moving towards the provider using the term `team` as well, but that is a larger change that must be planned carefully.

I've also removed the requirement for `HEROKU_EMAIL` to be set for acceptance tests because as long as `HEROKU_API_KEY` is set (which is already required), specifying an email is not necessary.