### PR TITLE
Ability to hide config vars from Plan Output

### DIFF
--- a/heroku/helper.go
+++ b/heroku/helper.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/heroku/heroku-go/v3"
+	"reflect"
 )
 
 // getAppName extracts the app attribute generically from a Heroku resource.
@@ -64,4 +65,17 @@ func getAppUuid(appName string, client *heroku.Service) string {
 	app, _ := doesHerokuAppExist(appName, client)
 
 	return app.ID
+}
+
+func SliceExists(slice interface{}, item interface{}) bool {
+	s := reflect.ValueOf(slice)
+	if s.Kind() != reflect.Slice {
+		panic("SliceExists() given a non-slice type")
+	}
+	for i := 0; i < s.Len(); i++ {
+		if s.Index(i).Interface() == item {
+			return true
+		}
+	}
+	return false
 }

--- a/heroku/helper.go
+++ b/heroku/helper.go
@@ -41,6 +41,7 @@ func doesHerokuAppExist(appName string, client *heroku.Service) (*heroku.App, er
 		log.Println(err)
 		return nil, fmt.Errorf("[ERROR] Your app does not exist")
 	}
+
 	return app, nil
 }
 
@@ -57,4 +58,10 @@ func parseCompositeID(id string) (p1 string, p2 string, err error) {
 		err = fmt.Errorf("error: Import composite ID requires two parts separated by colon, eg x:y")
 	}
 	return
+}
+
+func getAppUuid(appName string, client *heroku.Service) string {
+	app, _ := doesHerokuAppExist(appName, client)
+
+	return app.ID
 }

--- a/heroku/import_heroku_app_config_var_test.go
+++ b/heroku/import_heroku_app_config_var_test.go
@@ -1,0 +1,28 @@
+package heroku
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"testing"
+)
+
+func TestAccHerokuAppConfigVar_importBasic(t *testing.T) {
+	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuAppConfigVar_Basic(appName),
+			},
+			{
+				ResourceName:      "heroku_app_config_var.foobar-configs",
+				ImportStateId:     fmt.Sprintf("%s:%s:%s", appName, "public", "ENVIRONMENT,USER"),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/heroku/provider.go
+++ b/heroku/provider.go
@@ -68,6 +68,7 @@ func Provider() terraform.ResourceProvider {
 			"heroku_addon":                             resourceHerokuAddon(),
 			"heroku_addon_attachment":                  resourceHerokuAddonAttachment(),
 			"heroku_app":                               resourceHerokuApp(),
+			"heroku_app_config_var":                    resourceHerokuAppConfigVar(),
 			"heroku_app_feature":                       resourceHerokuAppFeature(),
 			"heroku_app_release":                       resourceHerokuAppRelease(),
 			"heroku_build":                             resourceHerokuBuild(),

--- a/heroku/resource_heroku_app.go
+++ b/heroku/resource_heroku_app.go
@@ -629,38 +629,6 @@ func retrieveConfigVars(id string, client *heroku.Service) (map[string]string, e
 	return nonNullVars, nil
 }
 
-// Updates the config vars for from an expanded configuration.
-func updateConfigVars(
-	id string,
-	client *heroku.Service,
-	o []interface{},
-	n []interface{}) error {
-	vars := make(map[string]*string)
-
-	for _, v := range o {
-		if v != nil {
-			for k := range v.(map[string]interface{}) {
-				vars[k] = nil
-			}
-		}
-	}
-	for _, v := range n {
-		if v != nil {
-			for k, v := range v.(map[string]interface{}) {
-				val := v.(string)
-				vars[k] = &val
-			}
-		}
-	}
-
-	log.Printf("[INFO] Updating config vars: *%#v", vars)
-	if _, err := client.ConfigVarUpdate(context.TODO(), id, vars); err != nil {
-		return fmt.Errorf("Error updating config vars: %s", err)
-	}
-
-	return nil
-}
-
 func updateBuildpacks(id string, client *heroku.Service, v []interface{}) error {
 	opts := heroku.BuildpackInstallationUpdateOpts{
 		Updates: []struct {
@@ -733,4 +701,36 @@ func releaseStateRefreshFunc(client *heroku.Service, appID, releaseID string) re
 		// heroku-go is updated.
 		return (*heroku.Release)(release), release.Status, nil
 	}
+}
+
+// Updates the config vars for from an expanded configuration.
+func updateConfigVars(
+	id string,
+	client *heroku.Service,
+	o []interface{},
+	n []interface{}) error {
+	vars := make(map[string]*string)
+
+	for _, v := range o {
+		if v != nil {
+			for k := range v.(map[string]interface{}) {
+				vars[k] = nil
+			}
+		}
+	}
+	for _, v := range n {
+		if v != nil {
+			for k, v := range v.(map[string]interface{}) {
+				val := v.(string)
+				vars[k] = &val
+			}
+		}
+	}
+
+	log.Printf("[INFO] Updating config vars: *%#v", vars)
+	if _, err := client.ConfigVarUpdate(context.TODO(), id, vars); err != nil {
+		return fmt.Errorf("Error updating config vars: %s", err)
+	}
+
+	return nil
 }

--- a/heroku/resource_heroku_app_config_var.go
+++ b/heroku/resource_heroku_app_config_var.go
@@ -67,6 +67,8 @@ func resourceHerokuAppConfigVarImport(d *schema.ResourceData, meta interface{}) 
 		app = parts[0]
 		configType = parts[1]
 		variable = parts[2]
+
+		log.Printf("[INFO] Information extracted for import - App: %s, ConfigType: %s, Variable: %s", app, configType, variable)
 	} else {
 		return nil, fmt.Errorf("error: Importing app config var requires three parts separated by a colon - <app_id>:public:var1,var2")
 	}
@@ -74,7 +76,7 @@ func resourceHerokuAppConfigVarImport(d *schema.ResourceData, meta interface{}) 
 	// Validate configType to make sure that only public/private is passed in
 	validTypes := []string{"public", "private"}
 	if !SliceExists(validTypes, configType) {
-		return nil, fmt.Errorf("nly public & private config variable type allowed. You passed in %s", configType)
+		return nil, fmt.Errorf("only public & private config variable type allowed. You passed in %s", configType)
 	}
 
 	// Get remote config variables and add them to state
@@ -86,14 +88,18 @@ func resourceHerokuAppConfigVarImport(d *schema.ResourceData, meta interface{}) 
 	}
 
 	vars := map[string]*string{}
-
 	for _, k := range variables {
 		if v, ok := configVars[k]; !ok {
 			vars[k] = v
 		}
 	}
 
+	d.SetId(app)
+	d.Set("app", app)
+	d.Set("all_config_vars", configVars)
 	d.Set(configType, vars)
+
+	fmt.Println("yolol123")
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/heroku/resource_heroku_app_config_var.go
+++ b/heroku/resource_heroku_app_config_var.go
@@ -1,0 +1,161 @@
+package heroku
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/heroku/heroku-go/v3"
+	"log"
+)
+
+func resourceHerokuAppConfigVar() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceHerokuAppConfigVarCreate, // There is no CREATE endpoint for config-vars
+		Read:   resourceHerokuAppConfigVarRead,
+		Update: resourceHerokuAppConfigVarUpdate,
+		Delete: resourceHerokuAppConfigVarDelete,
+		// TODO: should we handle scenario where a private var is in the public one?
+
+		Schema: map[string]*schema.Schema{
+			"app": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"public": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeMap,
+				},
+			},
+
+			"private": {
+				Type:      schema.TypeSet,
+				Optional:  true,
+				Sensitive: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeMap,
+				},
+			},
+		},
+	}
+}
+
+func resourceHerokuAppConfigVarCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Config).Api
+
+	// Get App Name
+	appName := getAppName(d)
+
+	// Define the Public & Private vars
+	var publicVars, privateVars map[string]interface{}
+	if v, ok := d.GetOk("public"); ok {
+		publicVars = v.(map[string]interface{})
+	}
+	if v, ok := d.GetOk("private"); ok {
+		privateVars = v.(map[string]interface{})
+	}
+
+	// Combine `public` & `private` config vars together and remove duplicates
+	configVars := mergeMaps(publicVars, privateVars)
+
+	// Create Config Vars for App
+	log.Printf("[INFO] Creating %s's config vars: *%#v", appName, configVars)
+
+	if _, err := client.ConfigVarUpdate(context.TODO(), appName, configVars); err != nil {
+		return fmt.Errorf("[ERROR] Error creating %s's config vars: %s", appName, err)
+	}
+
+	return resourceHerokuAppConfigVarRead(d, meta)
+}
+
+func resourceHerokuAppConfigVarRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*heroku.Service)
+
+	// Get App Name
+	appName := getAppName(d)
+
+	//// Get the App Id that we will use as this resource's Id
+	//appUuid := getAppUuid(appName, client)
+	configVars, err := client.ConfigVarInfoForApp(context.TODO(), appName)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(appName)
+	if err := d.Set("config_vars", configVars); err != nil {
+		log.Printf("[WARN] Error setting config vars: %s", err)
+	}
+
+	return nil
+}
+
+func resourceHerokuAppConfigVarUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*heroku.Service)
+
+	// Determine if public vars have changed
+	var oldPublicVars, newPublicVars interface{}
+	if d.HasChange("public") {
+		oldPublicVars, newPublicVars = d.GetChange("public")
+
+		if oldPublicVars == nil {
+			oldPublicVars = []interface{}{}
+		}
+		if newPublicVars == nil {
+			newPublicVars = []interface{}{}
+		}
+	}
+
+	// Determine if private vars have changed
+	var oldPrivateVars, newPrivateVars interface{}
+	if d.HasChange("public") {
+		oldPrivateVars, newPrivateVars = d.GetChange("private")
+
+		if oldPrivateVars == nil {
+			oldPrivateVars = []interface{}{}
+		}
+		if newPrivateVars == nil {
+			newPrivateVars = []interface{}{}
+		}
+	}
+
+	// Merge old and public vars together
+	oldVars := []interface{}{}
+	o := append(oldVars, oldPrivateVars)
+	o = append(oldVars, oldPublicVars)
+
+	newVars := []interface{}{}
+	n := append(newVars, newPrivateVars)
+	n = append(newVars, newPublicVars)
+
+	// Update Vars
+	err := updateConfigVars(
+		d.Id(), client, o, n)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Removing the app_config_var resource means moving all config vars from the given app
+func resourceHerokuAppConfigVarDelete(d *schema.ResourceData, meta interface{}) error {
+	// Essentially perform an Update and then remove the resource from State
+	resourceHerokuAppConfigVarUpdate(d, meta)
+
+	d.SetId("")
+	return nil
+}
+
+func mergeMaps(maps ...map[string]interface{}) map[string]*string {
+	result := make(map[string]*string)
+	for _, m := range maps {
+		for k, v := range m {
+			result[k] = v.(*string)
+		}
+	}
+	return result
+}

--- a/heroku/resource_heroku_app_config_var.go
+++ b/heroku/resource_heroku_app_config_var.go
@@ -53,30 +53,6 @@ func resourceHerokuAppConfigVar() *schema.Resource {
 	}
 }
 
-func getConfigVarsDiff(old []interface{}, new []interface{}) (vars map[string]*string) {
-	vars = make(map[string]*string)
-
-	for _, v := range old {
-		if v != nil {
-			for k := range v.(map[string]interface{}) {
-				vars[k] = nil
-			}
-		}
-	}
-	for _, v := range new {
-		if v != nil {
-			for k, v := range v.(map[string]interface{}) {
-				val := v.(string)
-				vars[k] = &val
-			}
-		}
-	}
-
-	log.Printf("[INFO] Config vars difference: *%#v", vars)
-
-	return vars
-}
-
 func resourceHerokuAppConfigVarCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Config).Api
 
@@ -269,7 +245,7 @@ func updateVars(d *schema.ResourceData, client *heroku.Service, public, private 
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"succeeded"},
-		Refresh: releaseStateRefreshFunc(client, d.Id(), releases[0].ID),
+		Refresh: releaseStateRefreshFunc(client, appName, releases[0].ID),
 		Timeout: 20 * time.Minute,
 	}
 
@@ -288,4 +264,28 @@ func mergeMaps(maps ...map[string]*string) map[string]*string {
 		}
 	}
 	return result
+}
+
+func getConfigVarsDiff(old []interface{}, new []interface{}) (vars map[string]*string) {
+	vars = make(map[string]*string)
+
+	for _, v := range old {
+		if v != nil {
+			for k := range v.(map[string]interface{}) {
+				vars[k] = nil
+			}
+		}
+	}
+	for _, v := range new {
+		if v != nil {
+			for k, v := range v.(map[string]interface{}) {
+				val := v.(string)
+				vars[k] = &val
+			}
+		}
+	}
+
+	log.Printf("[INFO] Config vars difference: *%#v", vars)
+
+	return vars
 }

--- a/heroku/resource_heroku_app_config_var_test.go
+++ b/heroku/resource_heroku_app_config_var_test.go
@@ -26,9 +26,11 @@ func TestAccHerokuAppConfigVars_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAppConfigVarExists("heroku_app_config_var.foobar-configs", &appConfigVars),
 					resource.TestCheckResourceAttr(
-						"heroku_app_config_var.foobar-configs", "public.#", "1"),
+						"heroku_app_config_var.foobar-configs", "public.0.ENVIRONMENT", "production"),
 					resource.TestCheckResourceAttr(
-						"heroku_app_config_var.foobar-configs", "private.#", "1"),
+						"heroku_app_config_var.foobar-configs", "private.0.PRIVATE_KEY", "some private key chain"),
+					resource.TestCheckResourceAttr(
+						"heroku_app_config_var.foobar-configs", "all_config_vars.%", "4"),
 				),
 			},
 		},
@@ -70,12 +72,13 @@ resource "heroku_app" "foobar" {
 
 resource "heroku_app_config_var" "foobar-configs" {
     app = "${heroku_app.foobar.name}"
-    public = {
+
+    public {
 		ENVIRONMENT = "production"
 		USER = "foobar-user"
 	}
 
-	private = {
+	private {
 		DATABASE_URL = "some.secret.url"
 		PRIVATE_KEY = "some private key chain"
 	}

--- a/heroku/resource_heroku_app_config_var_test.go
+++ b/heroku/resource_heroku_app_config_var_test.go
@@ -86,3 +86,28 @@ resource "heroku_app_config_var" "foobar-configs" {
 
 `, appName)
 }
+
+func testAccCheckHerokuAppConfigVar_Duplicates(appName string) string {
+	return fmt.Sprintf(`
+resource "heroku_app" "foobar" {
+    name = "%s"
+    region = "us"
+}
+
+resource "heroku_app_config_var" "foobar-configs" {
+    app = "${heroku_app.foobar.name}"
+
+    public {
+		ENVIRONMENT = "production"
+		USER = "foobar-user"
+		PRIVATE_KEY = "some private key chain"
+	}
+
+	private {
+		DATABASE_URL = "some.secret.url"
+		PRIVATE_KEY = "some private key chain"
+	}
+}
+
+`, appName)
+}

--- a/heroku/resource_heroku_app_config_var_test.go
+++ b/heroku/resource_heroku_app_config_var_test.go
@@ -3,10 +3,10 @@ package heroku
 import (
 	"context"
 	"fmt"
-	"github.com/cyberdelia/heroku-go/v3"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/heroku/heroku-go/v3"
 	"testing"
 )
 
@@ -25,6 +25,10 @@ func TestAccHerokuAppConfigVars_basic(t *testing.T) {
 				Config: testAccCheckHerokuAppConfigVar_Basic(appName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAppConfigVarExists("heroku_app_config_var.foobar-configs", &appConfigVars),
+					resource.TestCheckResourceAttr(
+						"heroku_app_config_var.foobar-configs", "public.#", "1"),
+					resource.TestCheckResourceAttr(
+						"heroku_app_config_var.foobar-configs", "private.#", "1"),
 				),
 			},
 		},
@@ -43,7 +47,7 @@ func testAccCheckHerokuAppConfigVarExists(n string, appConfigVar *heroku.ConfigV
 			return fmt.Errorf("No App Config Var ID set")
 		}
 
-		client := testAccProvider.Meta().(*heroku.Service)
+		client := testAccProvider.Meta().(*Config).Api
 
 		appName := rs.Primary.Attributes["app"]
 		foundAppConfigVar, err := client.ConfigVarInfoForApp(context.TODO(), appName)

--- a/heroku/resource_heroku_app_config_var_test.go
+++ b/heroku/resource_heroku_app_config_var_test.go
@@ -1,0 +1,81 @@
+package heroku
+
+import (
+	"context"
+	"fmt"
+	"github.com/cyberdelia/heroku-go/v3"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"testing"
+)
+
+func TestAccHerokuAppConfigVars_basic(t *testing.T) {
+	var appConfigVars heroku.ConfigVarInfoForAppResult
+
+	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuAppConfigVar_Basic(appName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHerokuAppConfigVarExists("heroku_app_config_var.foobar-configs", &appConfigVars),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckHerokuAppConfigVarExists(n string, appConfigVar *heroku.ConfigVarInfoForAppResult) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No App Config Var ID set")
+		}
+
+		client := testAccProvider.Meta().(*heroku.Service)
+
+		appName := rs.Primary.Attributes["app"]
+		foundAppConfigVar, err := client.ConfigVarInfoForApp(context.TODO(), appName)
+		if err != nil {
+			return err
+		}
+
+		*appConfigVar = foundAppConfigVar
+
+		return nil
+	}
+}
+
+func testAccCheckHerokuAppConfigVar_Basic(appName string) string {
+	return fmt.Sprintf(`
+resource "heroku_app" "foobar" {
+    name = "%s"
+    region = "us"
+}
+
+resource "heroku_app_config_var" "foobar-configs" {
+    app = "${heroku_app.foobar.name}"
+    public = {
+		ENVIRONMENT = "production"
+		USER = "foobar-user"
+	}
+
+	private = {
+		DATABASE_URL = "some.secret.url"
+		PRIVATE_KEY = "some private key chain"
+	}
+}
+
+`, appName)
+}

--- a/heroku/resource_heroku_app_config_var_test.go
+++ b/heroku/resource_heroku_app_config_var_test.go
@@ -102,11 +102,6 @@ resource "heroku_app_config_var" "foobar-configs" {
 		USER = "foobar-user"
 		PRIVATE_KEY = "some private key chain"
 	}
-
-	private {
-		DATABASE_URL = "some.secret.url"
-		PRIVATE_KEY = "some private key chain"
-	}
 }
 
 `, appName)

--- a/heroku/resource_heroku_formation_test.go
+++ b/heroku/resource_heroku_formation_test.go
@@ -72,7 +72,7 @@ func testAccCheckHerokuFormationExists(n string, formation *heroku.Formation) re
 		rs, ok := s.RootModule().Resources[n]
 
 		if !ok {
-			return fmt.Errorf("Formation not found: %s", n)
+			return fmt.Errorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
@@ -91,7 +91,9 @@ func testAccCheckHerokuFormationExists(n string, formation *heroku.Formation) re
 			return fmt.Errorf("Formation not found")
 		}
 
-		*formation = *foundFormation
+		if *formation != *foundFormation {
+			return fmt.Errorf("Formation not found")
+		}
 
 		return nil
 	}

--- a/website/docs/r/app_config_vars.html.markdown
+++ b/website/docs/r/app_config_vars.html.markdown
@@ -1,0 +1,47 @@
+---
+layout: "heroku"
+page_title: "Heroku: heroku_app_config_vars"
+sidebar_current: "docs-heroku-resource-app-config-vars"
+description: |-
+  Provides a Heroku App Config Variables resource. This can be used to create and manage configs variables for a heroku app.
+---
+
+# heroku\_app\_config\_vars
+
+Provides a Heroku App Config Variables resource. This can be used to create and manage configs variables for a heroku app.
+
+## Example Usage
+
+```hcl
+resource "heroku_app_config_vars" "foobar" {
+  app = "${heroku_app.foobar.name}"
+
+  public {
+    name = "RAILS_ENV"
+    value = "staging"
+  }
+
+  private {
+    name = "DATABASE_URL"
+    value = "postgres://user:password@some-host.com:1234"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `app` - (Required) The Heroku app to link to.
+* `public` - (Optional) Configuration variables for the application.
+    The config variables in this map are not the final set of configuration
+    variables, but rather variables you want present. That is, other
+    configuration variables set externally won't be removed by Terraform
+    if they aren't present in this list.
+* `private` - (Optional) Same as the `public` argument;
+    however these config variables will not get displayed in logs or regular output.
+    It is recommended one add passwords, tokens or other secret fields to this argument.
+
+## Migrating from config vars defined under the `heroku_app` resource:
+TODO: FINISH ME
+

--- a/website/heroku.erb
+++ b/website/heroku.erb
@@ -46,6 +46,10 @@
                       <a href="/docs/providers/heroku/r/app.html">heroku_app</a>
                     </li>
 
+                  <li<%= sidebar_current("docs-heroku-resource-app-config-vars") %>>
+                    <a href="/docs/providers/heroku/r/app_config_vars.html">heroku_app_config_vars</a>
+                  </li>
+
                     <li<%= sidebar_current("docs-heroku-resource-app-feature") %>>
                       <a href="/docs/providers/heroku/r/app_feature.html">heroku_app_feature</a>
                     </li>


### PR DESCRIPTION
TODO:
- [x] Create
- [x] Update
- [x] Read
- [x] Delete
- [ ] Handle backwards compatibility with `heroku_app` config vars
- [x] Add validation to check if one config var is set in both arguments
- [x] Tests (especially to check for ouputs from `private` vars
- [ ] Document how to best handle moving from `heroku_app` config vars to new resource
- [ ] Mark `heroku_app` config vars as deprecated
- [ ]  Import

Example:

```hcl
resource "heroku_app_config_vars" "foobar" {
  app = "${heroku_app.foobar.name}"
   public {
    name = "RAILS_ENV"
    value = "staging"
  }
   private {
    name = "DATABASE_URL"
    value = "postgres://user:password@some-host.com:1234"
  }
}
```