### PR TITLE
Add `heroku_space_vpn_connection` to establish VPN connections

### DIFF
--- a/heroku/provider.go
+++ b/heroku/provider.go
@@ -48,6 +48,7 @@ func Provider() terraform.ResourceProvider {
 			"heroku_space":                             resourceHerokuSpace(),
 			"heroku_space_inbound_ruleset":             resourceHerokuSpaceInboundRuleset(),
 			"heroku_space_peering_connection_accepter": resourceHerokuSpacePeeringConnectionAccepter(),
+			"heroku_space_vpn_connection":              resourceHerokuSpaceVPNConnection(),
 			"heroku_team_collaborator":                 resourceHerokuTeamCollaborator(),
 		},
 

--- a/heroku/resource_heroku_space_vpn_connection.go
+++ b/heroku/resource_heroku_space_vpn_connection.go
@@ -1,0 +1,173 @@
+package heroku
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+	"time"
+
+	heroku "github.com/cyberdelia/heroku-go/v3"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceHerokuSpaceVPNConnection() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceHerokuSpaceVPNConnectionCreate,
+		Read:   resourceHerokuSpaceVPNConnectionRead,
+		Delete: resourceHerokuSpaceVPNConnectionDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"space": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"public_ip": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"routable_cidrs": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Required: true,
+				ForceNew: true,
+			},
+
+			"space_cidr_block": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"ike_version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"tunnels": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Optional: true,
+
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+							Optional: true,
+						},
+
+						"pre_shared_key": {
+							Type:     schema.TypeString,
+							Computed: true,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceHerokuSpaceVPNConnectionRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*heroku.Service)
+	space := d.Get("space").(string)
+
+	conn, err := client.VPNConnectionInfo(context.TODO(), space, d.Id())
+	if err != nil {
+		return fmt.Errorf("Error reading VPN information: %v", err)
+	}
+
+	d.Set("space", space)
+	d.Set("name", conn.Name)
+	d.Set("public_ip", conn.PublicIP)
+	d.Set("routable_cidrs", conn.RoutableCidrs)
+	d.Set("space_cidr_block", conn.SpaceCIDRBlock)
+	d.Set("ike_version", conn.IKEVersion)
+
+	tunnels := []map[string]interface{}{}
+	for _, t := range conn.Tunnels {
+		tunnels = append(tunnels, map[string]interface{}{
+			"ip":             t.IP,
+			"pre_shared_key": t.PreSharedKey,
+		})
+	}
+	d.Set("tunnels", tunnels)
+
+	return nil
+}
+
+func resourceHerokuSpaceVPNConnectionCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*heroku.Service)
+	space := d.Get("space").(string)
+
+	routableCIDRs := []string{}
+	for _, v := range d.Get("routable_cidrs").(*schema.Set).List() {
+		routableCIDRs = append(routableCIDRs, v.(string))
+	}
+
+	conn, err := client.VPNConnectionCreate(context.TODO(), space, heroku.VPNConnectionCreateOpts{
+		Name:          d.Get("name").(string),
+		PublicIP:      d.Get("public_ip").(string),
+		RoutableCidrs: routableCIDRs,
+	})
+	if err != nil {
+		return fmt.Errorf("Error creating VPN: %v", err)
+	}
+	id := conn.ID
+
+	log.Printf("[DEBUG] Waiting for VPN (%s) to be allocated", d.Id())
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"pending", "provisioning"},
+		Target:  []string{"active"},
+		Refresh: func() (interface{}, string, error) {
+			conn, err := client.VPNConnectionInfo(context.TODO(), space, id)
+			if err != nil {
+				if herr, ok := err.(*url.Error).Err.(heroku.Error); ok && herr.ID == "not_found" {
+					// VPN creation is eventually consistent
+					return nil, "pending", nil
+				}
+				return nil, "", fmt.Errorf("Error getting VPN status: %v", err)
+			}
+
+			return conn.ID, conn.Status, nil
+		},
+		Timeout: 45 * time.Minute,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for VPN to become available: %v", err)
+	}
+
+	d.SetId(id)
+
+	return resourceHerokuSpaceVPNConnectionRead(d, meta)
+}
+
+func resourceHerokuSpaceVPNConnectionDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*heroku.Service)
+	space := d.Get("space").(string)
+
+	_, err := client.VPNConnectionDestroy(context.TODO(), space, d.Id())
+	if err != nil {
+		return fmt.Errorf("Error deleting VPN: %v", err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/heroku/resource_heroku_space_vpn_connection.go
+++ b/heroku/resource_heroku_space_vpn_connection.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net/url"
 	"time"
 
 	heroku "github.com/cyberdelia/heroku-go/v3"
@@ -137,10 +136,6 @@ func resourceHerokuSpaceVPNConnectionCreate(d *schema.ResourceData, meta interfa
 		Refresh: func() (interface{}, string, error) {
 			conn, err := client.VPNConnectionInfo(context.TODO(), space, id)
 			if err != nil {
-				if herr, ok := err.(*url.Error).Err.(heroku.Error); ok && herr.ID == "not_found" {
-					// VPN creation is eventually consistent
-					return nil, "pending", nil
-				}
 				return nil, "", fmt.Errorf("Error getting VPN status: %v", err)
 			}
 

--- a/heroku/resource_heroku_space_vpn_connection.go
+++ b/heroku/resource_heroku_space_vpn_connection.go
@@ -84,9 +84,9 @@ func resourceHerokuSpaceVPNConnection() *schema.Resource {
 
 func resourceHerokuSpaceVPNConnectionRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*heroku.Service)
-	space := d.Get("space").(string)
+	space, id := parseCompositeID(d.Id())
 
-	conn, err := client.VPNConnectionInfo(context.TODO(), space, d.Id())
+	conn, err := client.VPNConnectionInfo(context.TODO(), space, id)
 	if err != nil {
 		return fmt.Errorf("Error reading VPN information: %v", err)
 	}
@@ -129,7 +129,7 @@ func resourceHerokuSpaceVPNConnectionCreate(d *schema.ResourceData, meta interfa
 	}
 	id := conn.ID
 
-	log.Printf("[DEBUG] Waiting for VPN (%s) to be allocated", d.Id())
+	log.Printf("[DEBUG] Waiting for VPN (%s) to be allocated", id)
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"pending", "provisioning"},
 		Target:  []string{"active"},
@@ -149,16 +149,16 @@ func resourceHerokuSpaceVPNConnectionCreate(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("Error waiting for VPN to become available: %v", err)
 	}
 
-	d.SetId(id)
+	d.SetId(buildCompositeID(space, id))
 
 	return resourceHerokuSpaceVPNConnectionRead(d, meta)
 }
 
 func resourceHerokuSpaceVPNConnectionDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*heroku.Service)
-	space := d.Get("space").(string)
+	space, id := parseCompositeID(d.Id())
 
-	_, err := client.VPNConnectionDestroy(context.TODO(), space, d.Id())
+	_, err := client.VPNConnectionDestroy(context.TODO(), space, id)
 	if err != nil {
 		return fmt.Errorf("Error deleting VPN: %v", err)
 	}

--- a/heroku/resource_heroku_space_vpn_connection_test.go
+++ b/heroku/resource_heroku_space_vpn_connection_test.go
@@ -1,0 +1,125 @@
+package heroku
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+
+	heroku "github.com/cyberdelia/heroku-go/v3"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccHerokuVPNConnection_basic(t *testing.T) {
+	var vpnConnection heroku.VPNConnection
+	spaceName := fmt.Sprintf("tftest1-%s", acctest.RandString(10))
+	org := os.Getenv("HEROKU_SPACES_ORGANIZATION")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			if org == "" {
+				t.Skip("HEROKU_SPACES_ORGANIZATION is not set; skipping test.")
+			}
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHerokuVPNConnectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				ResourceName: "heroku_space_vpn_connection.foobar",
+				Config:       testAccCheckHerokuVPNConnectionConfig_basic(spaceName, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHerokuVPNConnectionExists("heroku_space_vpn_connection.foobar", &vpnConnection),
+					testAccCheckHerokuVPNConnectionAttributes(&vpnConnection),
+					resource.TestCheckResourceAttr(
+						"heroku_space_vpn_connection.foobar", "space_cidr_block", "10.0.0.0/16"),
+					resource.TestCheckResourceAttr(
+						"heroku_space_vpn_connection.foobar", "ike_version", "1"),
+					resource.TestCheckResourceAttr(
+						"heroku_space_vpn_connection.foobar", "tunnels.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckHerokuVPNConnectionExists(n string, vpnConnection *heroku.VPNConnection) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No VPN connection ID set")
+		}
+
+		client := testAccProvider.Meta().(*heroku.Service)
+
+		space := rs.Primary.Attributes["space"]
+		foundVPNConnection, err := client.VPNConnectionInfo(context.TODO(), space, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if foundVPNConnection.ID != rs.Primary.ID {
+			return fmt.Errorf("VPN connection not found")
+		}
+
+		*vpnConnection = *foundVPNConnection
+
+		return nil
+	}
+}
+
+func testAccCheckHerokuVPNConnectionAttributes(vpnConnection *heroku.VPNConnection) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if vpnConnection.Name != "foobar" {
+			return fmt.Errorf("Bad VPN connection name: got %v, want %v", vpnConnection.Name, "foobar")
+		}
+		if !reflect.DeepEqual(vpnConnection.RoutableCidrs, []string{"10.100.0.0/16"}) {
+			return fmt.Errorf("Bad VPN routable CIDRs: got %v, want %v", vpnConnection.RoutableCidrs, []string{"10.100.0.0/16"})
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckHerokuVPNConnectionDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*heroku.Service)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "heroku_space_vpn_connection" {
+			continue
+		}
+
+		space := rs.Primary.Attributes["space"]
+		_, err := client.VPNConnectionInfo(context.TODO(), space, rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("VPN connection still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckHerokuVPNConnectionConfig_basic(spaceName string, orgName string) string {
+	return fmt.Sprintf(`
+resource "heroku_space" "foobar" {
+  name         = "%s"
+  organization = "%s"
+  region       = "virginia"
+}
+
+resource "heroku_space_vpn_connection" "foobar" {
+	space          = "${heroku_space.foobar.name}"
+	name           = "foobar"
+	public_ip      = "${element(heroku_space.foobar.outbound_ips, 0)}"
+	routable_cidrs = ["10.100.0.0/16"]
+}
+`, spaceName, orgName)
+}

--- a/heroku/resource_heroku_space_vpn_connection_test.go
+++ b/heroku/resource_heroku_space_vpn_connection_test.go
@@ -57,16 +57,15 @@ func testAccCheckHerokuVPNConnectionExists(n string, vpnConnection *heroku.VPNCo
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("No VPN connection ID set")
 		}
+		space, id := parseCompositeID(rs.Primary.ID)
 
 		client := testAccProvider.Meta().(*heroku.Service)
-
-		space := rs.Primary.Attributes["space"]
-		foundVPNConnection, err := client.VPNConnectionInfo(context.TODO(), space, rs.Primary.ID)
+		foundVPNConnection, err := client.VPNConnectionInfo(context.TODO(), space, id)
 		if err != nil {
 			return err
 		}
 
-		if foundVPNConnection.ID != rs.Primary.ID {
+		if foundVPNConnection.ID != id {
 			return fmt.Errorf("VPN connection not found")
 		}
 
@@ -97,8 +96,8 @@ func testAccCheckHerokuVPNConnectionDestroy(s *terraform.State) error {
 			continue
 		}
 
-		space := rs.Primary.Attributes["space"]
-		_, err := client.VPNConnectionInfo(context.TODO(), space, rs.Primary.ID)
+		space, id := parseCompositeID(rs.Primary.ID)
+		_, err := client.VPNConnectionInfo(context.TODO(), space, id)
 		if err == nil {
 			return fmt.Errorf("VPN connection still exists")
 		}

--- a/website/docs/r/space_vpn_connection.html.markdown
+++ b/website/docs/r/space_vpn_connection.html.markdown
@@ -1,0 +1,51 @@
+---
+layout: "heroku"
+page_title: "Heroku: heroku_space_vpn_connection"
+sidebar_current: "docs-heroku-resource-vpn-connection-x"
+description: |-
+  Create a VPN connection between a network and a Heroku Private Space.
+---
+
+# heroku\_space\_vpn\_connection
+
+Provides a resource for creating a VPN connection between a network and a Heroku Private Space. For more information, see [Private Spaces VPN Connection](https://devcenter.heroku.com/articles/private-space-vpn-connection?preview=1) in the Heroku DevCenter.
+
+~> **NOTE:** VPN connections are currently a beta feature that requires you email Heroku Support to have it enabled. Attempting to create a VPN connection without the feature enabled by Heroku Support will fail.
+
+## Example Usage
+
+```hcl
+// Create a new Heroku space
+resource "heroku_space" "default" {
+  name         = "test-space"
+  organization = "my-company"
+  region       = "virginia"
+}
+
+// Connect the Heroku space to another network with a VPN
+resource "heroku_space_vpn_connection" "office" {
+  name           = "office"
+  space          = "${heroku_space.default.name}"
+  public_ip      = "203.0.113.1"
+  routable_cidrs = ["192.168.1.0/24"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the VPN connection.
+* `space` - (Required) The name of the Heroku Private Space where the VPN connection will be established.
+* `public_ip` - (Required) The public IP address of the VPN endpoint on the network where the VPN connection will be established.
+* `routable_cidrs` - (Required) A list of IPv4 CIDR blocks used by the network where the VPN connection will be established.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `space_cidr_block` - The CIDR block for the Heroku Private Space. The network where the VPN will be established should be configured to route traffic destined for this CIDR block over the VPN link.
+* `ike_version` - The IKE version used to setup the IPsec tunnel.
+* `tunnels` - Details about each VPN tunnel endpoint.
+  * `ip` - The public IP address of the tunnel.
+  * `pre_shared_key` - The pre-shared IPSec secret for the tunnel.

--- a/website/heroku.erb
+++ b/website/heroku.erb
@@ -83,6 +83,10 @@
                       <a href="/docs/providers/heroku/r/space_peering_connection_accepter.html">heroku_space_peering_connection_accepter</a>
                     </li>
 
+                    <li<%= sidebar_current("docs-heroku-resource-space-vpn-connection") %>>
+                      <a href="/docs/providers/heroku/r/space_vpn_connection.html">heroku_space_vpn_connection</a>
+                    </li>
+
                     <li<%= sidebar_current("docs-heroku-resource-team-collaborator") %>>
                       <a href="/docs/providers/heroku/r/team_collaborator.html">heroku_team_collaborator</a>
                     </li>


### PR DESCRIPTION
This beta feature enables IPSec-based VPN tunnels to be created between a network and a Heroku Private Space.

While this feature is not generally available at this time, we ideally want the Terraform provider to support it at the time of launch.