### PR TITLE
Fix missing vpc_cidr attribute in data_source_heroku_space_peering_info

### DIFF
--- a/heroku/data_source_heroku_space_peering_info.go
+++ b/heroku/data_source_heroku_space_peering_info.go
@@ -32,7 +32,7 @@ func dataSourceHerokuSpacePeeringInfo() *schema.Resource {
 			},
 
 			"vpc_cidr": {
-				Type:     schema.TypeBool,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 

--- a/heroku/data_source_heroku_space_peering_info_test.go
+++ b/heroku/data_source_heroku_space_peering_info_test.go
@@ -29,6 +29,12 @@ func TestAccDatasourceHerokuSpacePeeringInfo_Basic(t *testing.T) {
 						"data.heroku_space_peering_info.foobar", "aws_region", "us-east-1"),
 					resource.TestCheckResourceAttrSet(
 						"data.heroku_space_peering_info.foobar", "vpc_id"),
+					resource.TestCheckResourceAttrSet(
+						"data.heroku_space_peering_info.foobar", "vpc_cidr"),
+					resource.TestCheckResourceAttrSet(
+						"data.heroku_space_peering_info.foobar", "dyno_cidr_blocks.#"),
+					resource.TestCheckResourceAttrSet(
+						"data.heroku_space_peering_info.foobar", "unavailable_cidr_blocks.#"),
 				),
 			},
 		},


### PR DESCRIPTION
Fixes error when attempting to read the attribute `vpc_cidr` in `data_source_heroku_space_peering_info`:

> Resource 'data.heroku_space_peering_info.default' does not have attribute 'vpc_cidr' for variable 'data.heroku_space_peering_info.default.vpc_cidr'

Thank you @bernerdschaefer for the pointers 🙇‍♂️