### PR TITLE
Add a heroku_team_member resource for managing members of a Heroku team

### DIFF
--- a/heroku/import_heroku_team_member_test.go
+++ b/heroku/import_heroku_team_member_test.go
@@ -1,0 +1,32 @@
+package heroku
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccHerokuTeamMember_importBasic(t *testing.T) {
+	team := testAccConfig.GetOrganizationOrAbort(t)
+	testUser := testAccConfig.GetUserOrAbort(t)
+	role := "member"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuTeamMember_Org(team, testUser, role),
+			},
+			{
+				ResourceName:      "heroku_team_member.foobar-member",
+				ImportStateId:     buildCompositeID(team, testUser),
+				ImportState:       true,
+				ImportStateVerify: true,
+				//				ImportStateVerifyIgnore: []string{"suppress_invites"},
+			},
+		},
+	})
+}

--- a/heroku/provider.go
+++ b/heroku/provider.go
@@ -51,6 +51,7 @@ func Provider() terraform.ResourceProvider {
 			"heroku_space_peering_connection_accepter": resourceHerokuSpacePeeringConnectionAccepter(),
 			"heroku_space_vpn_connection":              resourceHerokuSpaceVPNConnection(),
 			"heroku_team_collaborator":                 resourceHerokuTeamCollaborator(),
+			"heroku_team_member":                       resourceHerokuTeamMember(),
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{

--- a/heroku/resource_heroku_team_member.go
+++ b/heroku/resource_heroku_team_member.go
@@ -1,0 +1,123 @@
+package heroku
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	heroku "github.com/heroku/heroku-go/v3"
+)
+
+func resourceHerokuTeamMember() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceHerokuTeamMemberSet,
+		Read:   resourceHerokuTeamMemberRead,
+		Update: resourceHerokuTeamMemberSet,
+		Delete: resourceHerokuTeamMemberDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: resourceHerokuTeamMemberImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"team": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"email": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"role": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"federated": {
+				Type:     schema.TypeBool,
+				Default:  false,
+				Optional: true,
+			},
+		},
+	}
+}
+
+// Callback for schema.ResourceImporter
+func resourceHerokuTeamMemberImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	team, email := parseCompositeID(d.Id())
+	d.Set("team", team)
+	d.Set("email", email)
+	resourceHerokuSpaceAppAccessRead(d, meta)
+	return []*schema.ResourceData{d}, nil
+}
+
+// Callback for schema Resource.Create and schema Resource.Update
+func resourceHerokuTeamMemberSet(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*heroku.Service)
+
+	email := d.Get("email").(string)
+	federated := d.Get("federated").(bool)
+	role := d.Get("role").(string)
+
+	opts := heroku.TeamMemberCreateOrUpdateOpts{
+		Email:     email,
+		Role:      &role,
+		Federated: &federated,
+	}
+
+	_, err := client.TeamMemberCreateOrUpdate(context.TODO(), d.Get("team").(string), opts)
+	if err != nil {
+		return err
+	}
+
+	return resourceHerokuSpaceAppAccessRead(d, meta)
+}
+
+// Callback for schema Resource.Read
+func resourceHerokuTeamMemberRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*heroku.Service)
+	team, email := parseCompositeID(d.Id())
+
+	members, err := client.TeamMemberList(context.TODO(), team, &heroku.ListRange{Field: "email"})
+	if err != nil {
+		return err
+	}
+
+	var found heroku.TeamMember
+	for _, member := range members {
+		if member.Email == email {
+			found = member
+			break
+		}
+	}
+
+	if found.ID == "" {
+		return fmt.Errorf("Could not find member record for %s on team %s", email, team)
+	}
+
+	d.SetId(buildCompositeID(team, email))
+	d.Set("team", team)
+	d.Set("email", found.Email)
+	d.Set("role", found.Role)
+	d.Set("federated", found.Federated)
+
+	return nil
+}
+
+// Callback for schema Resource.Delete
+func resourceHerokuTeamMemberDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*heroku.Service)
+	team, email := parseCompositeID(d.Id())
+
+	_, err := client.TeamMemberDelete(context.TODO(), team, email)
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/heroku/resource_heroku_team_member.go
+++ b/heroku/resource_heroku_team_member.go
@@ -70,7 +70,7 @@ func resourceHerokuTeamMemberSet(d *schema.ResourceData, meta interface{}) error
 		Federated: &federated,
 	}
 
-	_, err := client.TeamMemberCreateOrUpdate(context.TODO(), d.Get("team").(string), opts)
+	_, err := client.TeamMemberCreateOrUpdate(context.TODO(), team, opts)
 	if err != nil {
 		return err
 	}

--- a/heroku/resource_heroku_team_member.go
+++ b/heroku/resource_heroku_team_member.go
@@ -51,7 +51,7 @@ func resourceHerokuTeamMemberImport(d *schema.ResourceData, meta interface{}) ([
 	team, email := parseCompositeID(d.Id())
 	d.Set("team", team)
 	d.Set("email", email)
-	resourceHerokuSpaceAppAccessRead(d, meta)
+	resourceHerokuTeamMemberRead(d, meta)
 	return []*schema.ResourceData{d}, nil
 }
 
@@ -62,6 +62,7 @@ func resourceHerokuTeamMemberSet(d *schema.ResourceData, meta interface{}) error
 	email := d.Get("email").(string)
 	federated := d.Get("federated").(bool)
 	role := d.Get("role").(string)
+	team := d.Get("team").(string)
 
 	opts := heroku.TeamMemberCreateOrUpdateOpts{
 		Email:     email,
@@ -74,7 +75,8 @@ func resourceHerokuTeamMemberSet(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	return resourceHerokuSpaceAppAccessRead(d, meta)
+	d.SetId(buildCompositeID(team, email))
+	return resourceHerokuTeamMemberRead(d, meta)
 }
 
 // Callback for schema Resource.Read
@@ -99,7 +101,6 @@ func resourceHerokuTeamMemberRead(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Could not find member record for %s on team %s", email, team)
 	}
 
-	d.SetId(buildCompositeID(team, email))
 	d.Set("team", team)
 	d.Set("email", found.Email)
 	d.Set("role", found.Role)

--- a/heroku/resource_heroku_team_member_test.go
+++ b/heroku/resource_heroku_team_member_test.go
@@ -1,0 +1,80 @@
+package heroku
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	heroku "github.com/heroku/heroku-go/v3"
+)
+
+func TestAccHerokuTeamMember_Org(t *testing.T) {
+	team := testAccConfig.GetAnyOrganizationOrSkip(t)
+	testUser := testAccConfig.GetUserOrSkip(t)
+	role := "member"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuTeamMember_Org(team, testUser, role),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHerokuTeamMemberExists("heroku_team_member.foobar-member"),
+					resource.TestCheckResourceAttr(
+						"heroku_team_member.foobar-member", "role", "member"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckHerokuTeamMemberExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("[ERROR] Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("[ERROR] No Team Member Set")
+		}
+
+		team, email := parseCompositeID(rs.Primary.ID)
+		client := testAccProvider.Meta().(*heroku.Service)
+
+		members, err := client.TeamMemberList(context.TODO(), team, &heroku.ListRange{Field: "email"})
+		if err != nil {
+			return err
+		}
+
+		var foundMember heroku.TeamMember
+		for _, member := range members {
+			if member.Email == email {
+				foundMember = member
+				break
+			}
+		}
+
+		if foundMember.ID == "" {
+			return fmt.Errorf("Could not find member record for %s on team %s", email, team)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckHerokuTeamMember_Org(team, testUser, role string) string {
+	return fmt.Sprintf(`
+resource "heroku_team_member" "foobar-member" {
+	team  = "%s"
+	email = "%s"
+	role  = "%s"
+}
+`, team, testUser, role)
+}

--- a/website/docs/r/team_member.html.markdown
+++ b/website/docs/r/team_member.html.markdown
@@ -17,7 +17,7 @@ Provides a [Heroku Team Collaborator](https://devcenter.heroku.com/articles/plat
 ```hcl
 # Adds a Heroku user to a Heroku team as a viewer.
 resource "heroku_team_member" "foobar-member" {
-  team  = "${heroku_app.foobar.name}"
+  team  = "my-team"
   email = "some-user@example.com"
   role  = "member"
 }
@@ -34,5 +34,5 @@ resource "heroku_team_member" "foobar-member" {
 Team members can be imported using the combination of the team application name, a colon, and the member's email address.
 
 ```
-$ terraform import heroku_team_member.foobar-member foobar_app:some-user@example.com
+$ terraform import heroku_team_member.foobar-member my-team-foobar:some-user@example.com
 ```

--- a/website/docs/r/team_member.html.markdown
+++ b/website/docs/r/team_member.html.markdown
@@ -1,0 +1,38 @@
+---
+layout: "heroku"
+page_title: "Heroku: heroku_team_member"
+sidebar_current: "docs-heroku-resource-team-member"
+description: |-
+  Provides the ability to manage members of a Heroku team
+---
+
+# heroku\_team\_member
+
+Provides a [Heroku Team Collaborator](https://devcenter.heroku.com/articles/platform-api-reference#team-member) resource.
+
+~> **NOTE:** Please only use this resource if you have team/organization apps
+
+## Example Usage
+
+```hcl
+# Adds a Heroku user to a Heroku team as a viewer.
+resource "heroku_team_member" "foobar-member" {
+  team  = "${heroku_app.foobar.name}"
+  email = "some-user@example.com"
+  role  = "member"
+}
+```
+
+## Argument Reference
+
+* `team` - (Required) The name of the Heroku team that the team member will be added to.
+* `email` - (Required) Email address of the team collaborator
+* `role` - (Required) The role to assign the team member. See [the API docs](https://devcenter.heroku.com/articles/platform-api-reference#team-member) for available options.
+
+## Import
+
+Team members can be imported using the combination of the team application name, a colon, and the member's email address.
+
+```
+$ terraform import heroku_team_member.foobar-member foobar_app:some-user@example.com
+```

--- a/website/heroku.erb
+++ b/website/heroku.erb
@@ -94,6 +94,10 @@
                     <li<%= sidebar_current("docs-heroku-resource-team-collaborator") %>>
                       <a href="/docs/providers/heroku/r/team_collaborator.html">heroku_team_collaborator</a>
                     </li>
+
+                    <li<%= sidebar_current("docs-heroku-resource-team-member") %>>
+                      <a href="/docs/providers/heroku/r/team_member.html">heroku_team_member</a>
+                    </li>
         </ul>
         </li>
       </ul>


### PR DESCRIPTION
Tested with the following HCL:

```hcl
provider "heroku" {}

resource "heroku_team_member" "joe_test" {
  team  = "team-name"
  email = "someone@example.com"
  role  = "viewer"
}
```