### PR TITLE
Export the UUID of the Heroku app.

### DIFF
--- a/heroku/resource_heroku_app.go
+++ b/heroku/resource_heroku_app.go
@@ -28,6 +28,7 @@ type herokuApplication struct {
 	OrganizationName string
 	Locked           bool
 	Acm              bool
+	ID               string
 }
 
 // type application is used to store all the details of a heroku app
@@ -57,12 +58,16 @@ func (a *application) Update() error {
 		a.App.GitURL = app.GitURL
 		a.App.WebURL = app.WebURL
 		a.App.Acm = app.Acm
+		a.App.ID = app.ID
+
 		if app.InternalRouting != nil {
 			a.App.InternalRouting = *app.InternalRouting
 		}
+
 		if app.Space != nil {
 			a.App.Space = app.Space.Name
 		}
+
 		if app.Organization != nil {
 			a.App.OrganizationName = app.Organization.Name
 		} else {
@@ -126,6 +131,12 @@ func resourceHerokuApp() *schema.Resource {
 			},
 
 			"stack": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"uuid": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
@@ -377,6 +388,7 @@ func setAppDetails(d *schema.ResourceData, app *application) (err error) {
 	d.Set("git_url", app.App.GitURL)
 	d.Set("web_url", app.App.WebURL)
 	d.Set("acm", app.App.Acm)
+	d.Set("uuid", app.App.ID)
 	d.Set("heroku_hostname", fmt.Sprintf("%s.herokuapp.com", app.App.Name))
 	return err
 }

--- a/heroku/resource_heroku_app_test.go
+++ b/heroku/resource_heroku_app_test.go
@@ -28,6 +28,8 @@ func TestAccHerokuApp_Basic(t *testing.T) {
 					testAccCheckHerokuAppAttributes(&app, appName, "heroku-16"),
 					resource.TestCheckResourceAttr(
 						"heroku_app.foobar", "name", appName),
+					resource.TestCheckResourceAttrSet(
+						"heroku_app.foobar", "uuid"),
 					resource.TestCheckResourceAttr(
 						"heroku_app.foobar", "config_vars.0.FOO", "bar"),
 					resource.TestCheckResourceAttr(

--- a/website/docs/r/app.html.markdown
+++ b/website/docs/r/app.html.markdown
@@ -82,6 +82,7 @@ The following attributes are exported:
 * `all_config_vars` - A map of all of the configuration variables that
     exist for the app, containing both those set by Terraform and those
     set externally.
+* `uuid` - The unique UUID of the Heroku app. **NOTE:** Use this for `null_resource` triggers.
 
 ## Import
 


### PR DESCRIPTION
A use case was brought up in the `#terraform` channel today where someone was trying to use `null_resource` with `heroku_app.foo.id`, which is the app's name. The problem is that the `null_resource` triggers don't change even when the app is torn down and recreated.

This PR adds the UUID of the app to the exported attributes. Using this instead of `name` will allow `null_resource` triggers to fire when an app is recycled by TF.