### PR TITLE
Data source heroku addon

### DIFF
--- a/heroku/data_source_heroku_addon.go
+++ b/heroku/data_source_heroku_addon.go
@@ -1,0 +1,65 @@
+package heroku
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceHerokuAddon() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceHerokuAddonRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"app": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"plan": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"provider_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"config_vars": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func dataSourceHerokuAddonRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(*Config).Api
+
+	name := d.Get("name").(string)
+
+	addon, err := resourceHerokuAddonRetrieve(name, client)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(addon.ID)
+	d.Set("name", addon.Name)
+	d.Set("app", addon.App.Name)
+	d.Set("plan", addon.Plan.Name)
+	d.Set("provider_id", addon.ProviderID)
+	d.Set("config_vars", addon.ConfigVars)
+
+	return nil
+}

--- a/heroku/data_source_heroku_addon_test.go
+++ b/heroku/data_source_heroku_addon_test.go
@@ -1,0 +1,72 @@
+package heroku
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDatasourceHerokuAddon_Basic(t *testing.T) {
+	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuAddonBasic(appName),
+			},
+			{
+				Config: testAccCheckHerokuAddonWithDatasourceBasic(appName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.heroku_addon.test_data", "app", appName),
+					resource.TestCheckResourceAttr(
+						"data.heroku_addon.test_data", "plan", "deployhooks:http"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckHerokuAddonBasic(appName string) string {
+	return fmt.Sprintf(`
+resource "heroku_app" "foobar" {
+    name = "%s"
+    region = "us"
+}
+
+resource "heroku_addon" "foobar" {
+    app = "${heroku_app.foobar.name}"
+    plan = "deployhooks:http"
+    config {
+        url = "http://google.com"
+    }
+}
+`, appName)
+}
+
+func testAccCheckHerokuAddonWithDatasourceBasic(appName string) string {
+	return fmt.Sprintf(`
+resource "heroku_app" "foobar" {
+    name = "%s"
+    region = "us"
+}
+
+resource "heroku_addon" "foobar" {
+    app = "${heroku_app.foobar.name}"
+    plan = "deployhooks:http"
+    config {
+        url = "http://google.com"
+    }
+}
+
+data "heroku_addon" "test_data" {
+  name = "${heroku_addon.foobar.id}"
+}
+`, appName)
+}

--- a/heroku/provider.go
+++ b/heroku/provider.go
@@ -60,9 +60,10 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"heroku_addon":              dataSourceHerokuAddon(),
+			"heroku_app":                dataSourceHerokuApp(),
 			"heroku_space":              dataSourceHerokuSpace(),
 			"heroku_space_peering_info": dataSourceHerokuSpacePeeringInfo(),
-			"heroku_app":                dataSourceHerokuApp(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/website/docs/d/addon.html.markdown
+++ b/website/docs/d/addon.html.markdown
@@ -1,0 +1,47 @@
+---
+layout: "heroku"
+page_title: "Heroku: heroku_addon"
+sidebar_current: "docs-heroku-datasource-addon-x"
+description: |-
+  Get information on a Heroku Addon.
+---
+
+# Data Source: heroku_addon
+
+Use this data source to get information about a Heroku Addon.
+
+## Example Usage
+
+```hcl
+data "heroku_addon" "from_another_app" {
+  name = "addon-from-another-app"
+}
+
+output "heroku_addon_data_basic" {
+  value = [
+    "Addon from another app",
+    "id: ${data.heroku_addon.from_another_app.id}",
+    "name: ${data.heroku_addon.from_another_app.name}",
+    "app: ${data.heroku_addon.from_another_app.app}",
+    "plan: ${data.heroku_addon.from_another_app.plan}",
+    "provider_id: ${data.heroku_addon.from_another_app.provider_id}",
+    "config_vars: ${join(", ", data.heroku_addon.from_another_app.config_vars)}",
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The add-on name
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the add-on
+* `name` - The add-on name
+* `plan` - The plan name
+* `provider_id` - The ID of the plan provider
+* `config_vars` - The Configuration variables of the add-on

--- a/website/heroku.erb
+++ b/website/heroku.erb
@@ -13,6 +13,9 @@
         <li<%= sidebar_current("docs-heroku-datasource") %>>
         <a href="#">Data Sources</a>
                 <ul class="nav nav-visible">
+                    <li<%= sidebar_current("docs-heroku-datasource-addon") %>>
+          <a href="/docs/providers/heroku/d/addon.html">heroku_addon</a>
+                    </li>
                     <li<%= sidebar_current("docs-heroku-datasource-app") %>>
           <a href="/docs/providers/heroku/d/app.html">heroku_app</a>
                     </li>


### PR DESCRIPTION
I recently started experimenting with terraform and its Heroku provider and noticed that the provider lacks the `heroku_addon` data source.

It can be handy when you want to receive info about an addon defined externally or attach it to apps in your current config.


---

Example:
```
resource "heroku_app" "default" {
  name   = "terraform-test-container"
  region = "eu"

  stack = "container"
}

data "heroku_addon" "from_another_app" {
  name = "addon-from-another-app"
}

resource "heroku_addon_attachment" "database" {
  app_id   = "${heroku_app.default.id}"
  addon_id = "${data.heroku_addon.from_another_app.id}"
}

output "heroku_app_default" {
  value = [
    "App",
    "id: ${heroku_app.default.id}",
    "name: ${heroku_app.default.name}",
  ]
}

output "heroku_addon_data_basic" {
  value = [
    "Addon from another app",
    "id: ${data.heroku_addon.from_another_app.id}",
    "name: ${data.heroku_addon.from_another_app.name}",
    "app: ${data.heroku_addon.from_another_app.app}",
    "plan: ${data.heroku_addon.from_another_app.plan}",
    "provider_id: ${data.heroku_addon.from_another_app.provider_id}",
    "config_vars: ${join(", ", data.heroku_addon.from_another_app.config_vars)}",
  ]
}
```
