### PR TITLE
Fix Integration Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
-## 1.5.0 (Unreleased)
+## 1.4.1 (Unreleased)
+
+FEATURES:
+* Support for ~/.netrc authentication [#113](https://github.com/terraform-providers/terraform-provider-heroku/pull/113)
 
 IMPROVEMENTS:
 * `heroku_app` - Now exports the UUID Heroku assigns the app as `uuid` [#127](https://github.com/terraform-providers/terraform-provider-heroku/pull/127)
+* `heroku_slug` - Slug doc corrections & formatting [#125](https://github.com/terraform-providers/terraform-provider-heroku/pull/125)
+* Fixes code snippet in the README.md [#129](https://github.com/terraform-providers/terraform-provider-heroku/pull/129)
 
 ## 1.4.0 (September 11, 2018)
 

--- a/heroku/resource_heroku_app_test.go
+++ b/heroku/resource_heroku_app_test.go
@@ -511,7 +511,8 @@ func testAccCheckHerokuAppAttributesOrg(app *heroku.TeamApp, appName, space, org
 			return fmt.Errorf("Bad space: %s", appSpace)
 		}
 
-		if app.BuildStack.Name != "heroku-16" {
+		// This needs to be updated whenever heroku bumps the stack number
+		if app.BuildStack.Name != "heroku-18" {
 			return fmt.Errorf("Bad stack: %s", app.BuildStack.Name)
 		}
 

--- a/heroku/resource_heroku_slug_test.go
+++ b/heroku/resource_heroku_slug_test.go
@@ -96,7 +96,7 @@ func testAccCheckHerokuSlugExists(n string, Slug *heroku.Slug) resource.TestChec
 			return fmt.Errorf("No Slug ID is set")
 		}
 
-		client := testAccProvider.Meta().(*heroku.Service)
+		client := testAccProvider.Meta().(*Config).Api
 
 		foundSlug, err := client.SlugInfo(context.TODO(), rs.Primary.Attributes["app"], rs.Primary.ID)
 

--- a/heroku/resource_heroku_team_member_test.go
+++ b/heroku/resource_heroku_team_member_test.go
@@ -46,7 +46,7 @@ func testAccCheckHerokuTeamMemberExists(n string) resource.TestCheckFunc {
 		}
 
 		team, email := parseCompositeID(rs.Primary.ID)
-		client := testAccProvider.Meta().(*heroku.Service)
+		client := testAccProvider.Meta().(*Config).Api
 
 		members, err := client.TeamMemberList(context.TODO(), team, &heroku.ListRange{Field: "email"})
 		if err != nil {


### PR DESCRIPTION
The following have been flapping/erroring for a bit now:

```
18:54:07 --- FAIL: TestAccHerokuApp_Organization (2.60s)
18:54:07 	testing.go:518: Step 0 error: Check failed: Check 2/2 error: Bad stack: heroku-18
18:54:07 === RUN   TestAccHerokuApp_Space
18:54:07 --- FAIL: TestAccHerokuApp_Space (464.84s)
18:54:07 	testing.go:518: Step 0 error: Check failed: Check 2/2 error: Bad stack: heroku-18
18:54:07 === RUN   TestAccHerokuApp_Space_Internal
18:54:07 --- FAIL: TestAccHerokuApp_Space_Internal (442.58s)
18:54:07 	testing.go:518: Step 0 error: Check failed: Check 2/2 error: Bad stack: heroku-18
```

```
18:54:07 panic: interface conversion: interface {} is *heroku.Config, not *heroku.Service [recovered]
18:54:07 	panic: interface conversion: interface {} is *heroku.Config, not *heroku.Service
18:54:07 
18:54:07 goroutine 18696 [running]:
18:54:07 testing.tRunner.func1(0xc4202e0c30)
18:54:07 	/usr/local/go/src/testing/testing.go:711 +0x2d2
18:54:07 panic(0xd6c240, 0xc4205bebc0)
18:54:07 	/usr/local/go/src/runtime/panic.go:491 +0x283
18:54:07 github.com/terraform-providers/terraform-provider-heroku/heroku.testAccCheckHerokuSlugExists.func1(0xc420466000, 0xc4203e0d20, 0xe72e68)
18:54:07 	/home/jenkins/go/src/github.com/terraform-providers/terraform-provider-heroku/heroku/resource_heroku_slug_test.go:99 +0x402
18:54:07 github.com/terraform-providers/terraform-provider-heroku/vendor/github.com/hashicorp/terraform/helper/resource.ComposeTestCheckFunc.func1(0xc420466000, 0xc420466000, 0x0)
18:54:07 	/home/jenkins/go/src/github.com/terraform-providers/terraform-provider-heroku/vendor/github.com/hashicorp/terraform/helper/resource/testing.go:815 +0x88
18:54:07 github.com/terraform-providers/terraform-provider-heroku/vendor/github.com/hashicorp/terraform/helper/resource.testStep(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
18:54:07 	/home/jenkins/go/src/github.com/terraform-providers/terraform-provider-heroku/vendor/github.com/hashicorp/terraform/helper/resource/testing_config.go:81 +0xddc
18:54:07 github.com/terraform-providers/terraform-provider-heroku/vendor/github.com/hashicorp/terraform/helper/resource.testStepConfig(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
18:54:07 	/home/jenkins/go/src/github.com/terraform-providers/terraform-provider-heroku/vendor/github.com/hashicorp/terraform/helper/resource/testing_config.go:17 +0x98
18:54:07 github.com/terraform-providers/terraform-provider-heroku/vendor/github.com/hashicorp/terraform/helper/resource.Test(0x143d3a0, 0xc4202e0c30, 0x0, 0xc420570310, 0xc42022f110, 0x0, 0x0, 0x0, 0xc420308e70, 0x1, ...)
18:54:07 	/home/jenkins/go/src/github.com/terraform-providers/terraform-provider-heroku/vendor/github.com/hashicorp/terraform/helper/resource/testing.go:492 +0x1439
18:54:07 github.com/terraform-providers/terraform-provider-heroku/heroku.TestAccHerokuSlug_Basic(0xc4202e0c30)
18:54:07 	/home/jenkins/go/src/github.com/terraform-providers/terraform-provider-heroku/heroku/resource_heroku_slug_test.go:20 +0x2f2
18:54:07 testing.tRunner(0xc4202e0c30, 0xeadd10)
18:54:07 	/usr/local/go/src/testing/testing.go:746 +0xd0
18:54:07 created by testing.(*T).Run
18:54:07 	/usr/local/go/src/testing/testing.go:789 +0x2de
18:54:07 FAIL	github.com/terraform-providers/terraform-provider-heroku/heroku	2989.343s
```