### PR TITLE
Investigate & Fix the Following Test Failures

### DIFF
--- a/heroku/resource_heroku_domain_test.go
+++ b/heroku/resource_heroku_domain_test.go
@@ -31,8 +31,6 @@ func TestAccHerokuDomain_Basic(t *testing.T) {
 						"heroku_domain.foobar", "hostname", "terraform-tftest-"+randString+".example.com"),
 					resource.TestCheckResourceAttr(
 						"heroku_domain.foobar", "app", appName),
-					resource.TestCheckResourceAttr(
-						"heroku_domain.foobar", "cname", "terraform-tftest-"+randString+".example.com.herokudns.com"),
 				),
 			},
 		},
@@ -61,6 +59,10 @@ func testAccCheckHerokuDomainAttributes(Domain *heroku.Domain) resource.TestChec
 	return func(s *terraform.State) error {
 		if !strings.HasPrefix(Domain.Hostname, "terraform-") && !strings.HasSuffix(Domain.Hostname, ".example.com") {
 			return fmt.Errorf("Bad hostname: %s", Domain.Hostname)
+		}
+
+		if !strings.Contains(*Domain.CName, ".herokudns.com") {
+			return fmt.Errorf("Expected hostname to be [*.herokudns.com] but got: [%s]", *Domain.CName)
 		}
 
 		return nil


### PR DESCRIPTION
The following three test have been failing for a bit:

```
03:30:49 --- FAIL: TestAccHerokuSpaceAppAccess_importBasic (430.71s)
03:30:49 	testing.go:518: Step 0 error: Error applying: 1 error occurred:
03:30:49 			* heroku_space_app_access.foobar: 1 error occurred:
03:30:49 			* heroku_space_app_access.foobar: Patch https://api.heroku.com/spaces/tftest1-keuns4nk9t/members/****: Couldn't find that user.
```

```
03:30:49 --- FAIL: TestAccHerokuDomain_Basic (1.94s)
03:30:49 	testing.go:518: Step 0 error: Check failed: Check 5/5 error: heroku_domain.foobar: Attribute 'cname' expected "terraform-tftest-jxbeyywub0.example.com.herokudns.com", got "mechanistic-gorilla-tgcqkphfyw032xebcmam2ng3.herokudns.com"
```

```
03:30:49 --- FAIL: TestAccHerokuSpaceAppAccess_Basic (440.84s)
03:30:49 	testing.go:518: Step 0 error: Error applying: 1 error occurred:
03:30:49 			* heroku_space_app_access.foobar: 1 error occurred:
03:30:49 			* heroku_space_app_access.foobar: Patch https://api.heroku.com/spaces/tftest1-2ihxw8oxg6/members/****: Couldn't find that user.
03:30:49 		
03:30:49 		
03:30:49 		
03:30:49 	
```

We need to investigate and figure if the cause of these failures.