### PR TITLE
Fetch slug archives via HTTPS

### DIFF
--- a/heroku/import_heroku_slug_test.go
+++ b/heroku/import_heroku_slug_test.go
@@ -24,7 +24,8 @@ func TestAccHerokuSlug_importBasic(t *testing.T) {
 				ImportState:         true,
 				ImportStateVerify:   true,
 				// "blob" ignored because generated uniquely by Heroku for each Slug
-				ImportStateVerifyIgnore: []string{"blob"},
+				// "file_path" ignored because it is an ephemeral create-only attribute
+				ImportStateVerifyIgnore: []string{"blob", "file_path"},
 			},
 		},
 	})
@@ -46,13 +47,14 @@ func TestAccHerokuSlug_importAllOpts(t *testing.T) {
 				ImportState:         true,
 				ImportStateVerify:   true,
 				// "blob" ignored because generated uniquely by Heroku for each Slug
-				ImportStateVerifyIgnore: []string{"blob"},
+				// "file_path" ignored because it is an ephemeral create-only attribute
+				ImportStateVerifyIgnore: []string{"blob", "file_path"},
 			},
 		},
 	})
 }
 
-func TestAccHerokuSlug_importWithFile(t *testing.T) {
+func TestAccHerokuSlug_importWithFileUrl(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -60,7 +62,7 @@ func TestAccHerokuSlug_importWithFile(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuSlugConfig_withFile(appName),
+				Config: testAccCheckHerokuSlugConfig_withRemoteFile(appName),
 			},
 			{
 				ResourceName:        "heroku_slug.foobar",
@@ -68,8 +70,8 @@ func TestAccHerokuSlug_importWithFile(t *testing.T) {
 				ImportState:         true,
 				ImportStateVerify:   true,
 				// "blob" ignored because generated uniquely by Heroku for each Slug
-				// "file_path" ignored because it is an ephemeral create-only attribute
-				ImportStateVerifyIgnore: []string{"blob", "file_path"},
+				// "file_url" ignored because it is an ephemeral create-only attribute
+				ImportStateVerifyIgnore: []string{"blob", "file_url"},
 			},
 		},
 	})

--- a/heroku/resource_heroku_slug.go
+++ b/heroku/resource_heroku_slug.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"os"
+	"regexp"
 	"strings"
 
 	uuid "github.com/hashicorp/go-uuid"
@@ -47,6 +48,7 @@ func resourceHerokuSlug() *schema.Resource {
 				ConflictsWith: []string{"file_path"},
 				Optional:      true,
 				ForceNew:      true,
+				ValidateFunc:  validateFileUrl,
 			},
 
 			"blob": {
@@ -401,4 +403,20 @@ func cleanupFile(filePath string) {
 			log.Printf("[WARN] Error cleaning-up downloaded slug: %s (%s)", err, filePath)
 		}
 	}
+}
+
+func validateFileUrl(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if value == "" {
+		return
+	}
+
+	pattern := `^https://`
+	if !regexp.MustCompile(pattern).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q must be a secure URL, start with `https://`. Value is %q",
+			k, value))
+	}
+
+	return
 }

--- a/heroku/resource_heroku_slug_test.go
+++ b/heroku/resource_heroku_slug_test.go
@@ -124,6 +124,22 @@ func TestAccHerokuSlug_WithRemoteFile(t *testing.T) {
 	})
 }
 
+func TestAccHerokuSlug_WithInsecureRemoteFile(t *testing.T) {
+	randString := acctest.RandString(10)
+	appName := fmt.Sprintf("tftest-%s", randString)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckHerokuSlugConfig_withInsecureRemoteFile(appName),
+				ExpectError: regexp.MustCompile(`must be a secure URL`),
+			},
+		},
+	})
+}
+
 func TestAccHerokuSlug_WithFile_InPrivateSpace(t *testing.T) {
 	var slug heroku.Slug
 	randString := acctest.RandString(10)
@@ -256,6 +272,22 @@ resource "heroku_slug" "foobar" {
     app = "${heroku_app.foobar.name}"
     buildpack_provided_description = "Ruby"
     file_url = "https://github.com/terraform-providers/terraform-provider-heroku/raw/master/heroku/test-fixtures/slug.tgz"
+    process_types = {
+      web = "ruby server.rb"
+    }
+}`, appName)
+}
+
+func testAccCheckHerokuSlugConfig_withInsecureRemoteFile(appName string) string {
+	return fmt.Sprintf(`resource "heroku_app" "foobar" {
+    name = "%s"
+    region = "us"
+}
+
+resource "heroku_slug" "foobar" {
+    app = "${heroku_app.foobar.name}"
+    buildpack_provided_description = "Ruby"
+    file_url = "http://github.com/terraform-providers/terraform-provider-heroku/raw/master/heroku/test-fixtures/slug.tgz"
     process_types = {
       web = "ruby server.rb"
     }

--- a/website/docs/r/slug.html.markdown
+++ b/website/docs/r/slug.html.markdown
@@ -17,10 +17,10 @@ This resource supports uploading a pre-generated archive file of executable code
 
 Create a ready-to-release slug:
 
-* When `file_path` is specified, the file it references must contain a slug archive of executable code and must follow the prescribed layout from [Create slug archive](https://devcenter.heroku.com/articles/platform-api-deploying-slugs#create-slug-archive) in the Heroku Dev Center (nested within an `./app` directory)
-* When `file_path` is not specified, then the [slug archive must be uploaded](https://devcenter.heroku.com/articles/platform-api-deploying-slugs#publish-to-the-platform) to the resulting computed `blob.method` + `blob.url` by some other means, otherwise app release will fail with _Compiled slug couldn't be found_
+* When `file_url` or `file_path` is specified, the referenced file must contain a slug archive of executable code and must follow the prescribed layout from [Create slug archive](https://devcenter.heroku.com/articles/platform-api-deploying-slugs#create-slug-archive) in the Heroku Dev Center (nested within an `./app` directory)
+* When neither `file_url` nor `file_path` is specified, then the [slug archive must be uploaded](https://devcenter.heroku.com/articles/platform-api-deploying-slugs#publish-to-the-platform) to the resulting computed `blob.method` + `blob.url` by some other means, otherwise app release will fail with _Compiled slug couldn't be found_
 * The archive may be created by an external build system, downloaded from another Heroku app, or otherwise provided outside of the context of this Terraform resource
-* If the contents (SHA256) of the file at `file_path` change, then a new resource will be forced on the next plan/apply; if the file does not exist, the difference is ignored.
+* If the contents (SHA256) of the file change, then a new resource will be forced on the next plan/apply; if the file does not exist, the difference is ignored.
 
 ```hcl
 resource "heroku_slug" "foobar" {
@@ -81,7 +81,8 @@ The following arguments are supported:
 * `checksum` - Hash of the slug for verifying its integrity, auto-generated when `file_path` is set to upload a slug archive, `SHA256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
 * `commit` - Identification of the code with your version control system (eg: SHA of the git HEAD), `"60883d9e8947a57e04dc9124f25df004866a2051"`
 * `commit_description` - Description of the provided commit
-* `file_path` - Local path to a slug archive, see [Minimal Example](#minimal-example), `"slugs/current.tgz"`
+* `file_path` - Local path to a slug archive, may be overridden by `file_url`, `"slugs/current.tgz"`
+* `file_url` - https:// URL to a slug archive, overrides `file_path`, `"https://example.com/slugs/app-v1.tgz"`
 * `process_types` - (Required) Map of [processes to launch on Heroku Dynos](https://devcenter.heroku.com/articles/process-model)
 * `stack` - Name or ID of the [Heroku stack](https://devcenter.heroku.com/articles/stack)
 

--- a/website/docs/r/slug.html.markdown
+++ b/website/docs/r/slug.html.markdown
@@ -81,7 +81,7 @@ The following arguments are supported:
 * `commit` - Identification of the code with your version control system (eg: SHA of the git HEAD), `"60883d9e8947a57e04dc9124f25df004866a2051"`
 * `commit_description` - Description of the provided commit
 * `file_path` - (Required unless `file_url` is set) Local path to a slug archive, `"slugs/current.tgz"`
-* `file_url` - (Required unless `file_path` is set) https:// URL to a slug archive, `"https://example.com/slugs/app-v1.tgz"`
+* `file_url` - (Required unless `file_path` is set) **https** URL to a slug archive, `"https://example.com/slugs/app-v1.tgz"`
 * `process_types` - (Required) Map of [processes to launch on Heroku Dynos](https://devcenter.heroku.com/articles/process-model)
 * `stack` - Name or ID of the [Heroku stack](https://devcenter.heroku.com/articles/stack)
 

--- a/website/docs/r/slug.html.markdown
+++ b/website/docs/r/slug.html.markdown
@@ -17,16 +17,15 @@ This resource supports uploading a pre-generated archive file of executable code
 
 Create a ready-to-release slug:
 
-* When `file_url` or `file_path` is specified, the referenced file must contain a slug archive of executable code and must follow the prescribed layout from [Create slug archive](https://devcenter.heroku.com/articles/platform-api-deploying-slugs#create-slug-archive) in the Heroku Dev Center (nested within an `./app` directory)
-* When neither `file_url` nor `file_path` is specified, then the [slug archive must be uploaded](https://devcenter.heroku.com/articles/platform-api-deploying-slugs#publish-to-the-platform) to the resulting computed `blob.method` + `blob.url` by some other means, otherwise app release will fail with _Compiled slug couldn't be found_
+* `file_url` or `file_path` must reference a file containing a slug archive of executable code and must follow the prescribed layout from [Create slug archive](https://devcenter.heroku.com/articles/platform-api-deploying-slugs#create-slug-archive) in the Heroku Dev Center (nested within an `./app` directory)
 * The archive may be created by an external build system, downloaded from another Heroku app, or otherwise provided outside of the context of this Terraform resource
-* If the contents (SHA256) of the file change, then a new resource will be forced on the next plan/apply; if the file does not exist, the difference is ignored.
+* If the content (SHA256) of `file_path` changes, then a new resource will be forced on the next plan/apply; if the file does not exist, the difference is ignored.
+* The `file_url` is only fetched during resource creation. To trigger another fetch the `file_url` should be changed, then a new resource will be forced on the next plan/apply.
 
 ```hcl
 resource "heroku_slug" "foobar" {
-  app       = "${heroku_app.foobar.id}"
-  // The slug archive file must already exist
-  file_path = "slug.tgz"
+  app      = "${heroku_app.foobar.id}"
+  file_url = "https://github.com/terraform-providers/terraform-provider-heroku/raw/master/heroku/test-fixtures/slug.tgz"
 
   process_types = {
     web = "ruby server.rb"
@@ -78,11 +77,11 @@ The following arguments are supported:
 
 * `app` - (Required) The ID of the Heroku app
 * `buildpack_provided_description` - Description of language or app framework, `"Ruby/Rack"`; displayed as the app's language in the Heroku Dashboard
-* `checksum` - Hash of the slug for verifying its integrity, auto-generated when `file_path` is set to upload a slug archive, `SHA256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
+* `checksum` - Hash of the slug for verifying its integrity, auto-generated from contents of `file_path` or `file_url`, `SHA256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
 * `commit` - Identification of the code with your version control system (eg: SHA of the git HEAD), `"60883d9e8947a57e04dc9124f25df004866a2051"`
 * `commit_description` - Description of the provided commit
-* `file_path` - Local path to a slug archive, may be overridden by `file_url`, `"slugs/current.tgz"`
-* `file_url` - https:// URL to a slug archive, overrides `file_path`, `"https://example.com/slugs/app-v1.tgz"`
+* `file_path` - (Required unless `file_url` is set) Local path to a slug archive, `"slugs/current.tgz"`
+* `file_url` - (Required unless `file_path` is set) https:// URL to a slug archive, `"https://example.com/slugs/app-v1.tgz"`
 * `process_types` - (Required) Map of [processes to launch on Heroku Dynos](https://devcenter.heroku.com/articles/process-model)
 * `stack` - Name or ID of the [Heroku stack](https://devcenter.heroku.com/articles/stack)
 
@@ -96,7 +95,7 @@ The following attributes are exported:
   * `method` - HTTP method to upload the archive
   * `url` - Pre-signed, expiring URL to upload the archive
 * `buildpack_provided_description` - Description of language or app framework, `"Ruby/Rack"`
-* `checksum` - Hash of the slug for verifying its integrity, auto-generated when `file_path` is set to upload a slug archive, `SHA256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
+* `checksum` - Hash of the slug for verifying its integrity, auto-generated from contents of `file_path` or `file_url`
 * `commit` - Identification of the code with your version control system (eg: SHA of the git HEAD), `"60883d9e8947a57e04dc9124f25df004866a2051"`
 * `commit_description` - Description of the provided commit
 * `process_types` - Map of [processes to launch on Heroku Dynos](https://devcenter.heroku.com/articles/process-model)


### PR DESCRIPTION
We've been working on the **Launch a Heroku app via Terraform** story. Adding the `heroku_slug` resource got us 90% of the way there. It currently stops short by requiring that the slug archive already be located on the local filesystem.

This PR adds a `heroku_slug.file_url` attribute, to configure the HTTP URL of the slug archive. When the resource is created, the specified URL is downloaded to a unique, temporary file, and then treated as if it was set in `file_path`.

```hcl
resource "heroku_slug" "foobar" {
  app                            = "foobar"
  file_url                       = "https://marsikai.s3.amazonaws.com/slugs/ruby-hello-world.tgz"
  buildpack_provided_description = "Ruby"

  process_types = {
    web = "ruby server.rb"
  }
}
```

Based on discussion in this PR, the `heroku_slug` resource now requires either `file_path` or `file_url`, removing the complexity-inducing, upload-it-yourself option.