### PR TITLE
Add provider configuration for backend

### DIFF
--- a/heroku/config.go
+++ b/heroku/config.go
@@ -1,10 +1,11 @@
 package heroku
 
 import (
-	"github.com/hashicorp/terraform/helper/logging"
-	heroku "github.com/heroku/heroku-go/v3"
 	"log"
 	"net/http"
+
+	"github.com/hashicorp/terraform/helper/logging"
+	heroku "github.com/heroku/heroku-go/v3"
 )
 
 type Config struct {

--- a/heroku/config.go
+++ b/heroku/config.go
@@ -17,9 +17,9 @@ import (
 )
 
 const (
-	DefaultPostAppCreateDelay    = int64(10)
-	DefaultPostSpaceCreateDelay  = int64(10)
-	DefaultPostDomainCreateDelay = int64(10)
+	DefaultPostAppCreateDelay    = int64(5)
+	DefaultPostSpaceCreateDelay  = int64(5)
+	DefaultPostDomainCreateDelay = int64(5)
 )
 
 type Config struct {

--- a/heroku/config.go
+++ b/heroku/config.go
@@ -8,13 +8,21 @@ import (
 	heroku "github.com/heroku/heroku-go/v3"
 )
 
-type Config struct {
-	Email   string
-	APIKey  string
-	Headers http.Header
-	URL     string
+const (
+	DefaultPostAppCreateDelay    = int64(5)
+	DefaultPostSpaceCreateDelay  = int64(5)
+	DefaultPostDomainCreateDelay = int64(5)
+)
 
-	Api *heroku.Service
+type Config struct {
+	Api                   *heroku.Service
+	APIKey                string
+	Email                 string
+	Headers               http.Header
+	PostAppCreateDelay    int64
+	PostDomainCreateDelay int64
+	PostSpaceCreateDelay  int64
+	URL                   string
 }
 
 // Client returns a new Config for accessing Heroku.

--- a/heroku/config.go
+++ b/heroku/config.go
@@ -9,9 +9,9 @@ import (
 )
 
 const (
-	DefaultPostAppCreateDelay    = int64(5)
-	DefaultPostSpaceCreateDelay  = int64(5)
-	DefaultPostDomainCreateDelay = int64(5)
+	DefaultPostAppCreateDelay    = int64(8)
+	DefaultPostSpaceCreateDelay  = int64(8)
+	DefaultPostDomainCreateDelay = int64(8)
 )
 
 type Config struct {

--- a/heroku/config.go
+++ b/heroku/config.go
@@ -9,9 +9,9 @@ import (
 )
 
 const (
-	DefaultPostAppCreateDelay    = int64(8)
-	DefaultPostSpaceCreateDelay  = int64(8)
-	DefaultPostDomainCreateDelay = int64(8)
+	DefaultPostAppCreateDelay    = int64(5)
+	DefaultPostSpaceCreateDelay  = int64(5)
+	DefaultPostDomainCreateDelay = int64(5)
 )
 
 type Config struct {

--- a/heroku/config.go
+++ b/heroku/config.go
@@ -1,11 +1,19 @@
 package heroku
 
 import (
+	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
+	"net/url"
+	"os"
+	"runtime"
 
+	"github.com/bgentry/go-netrc/netrc"
 	"github.com/hashicorp/terraform/helper/logging"
+	"github.com/hashicorp/terraform/helper/schema"
 	heroku "github.com/heroku/heroku-go/v3"
+	homedir "github.com/mitchellh/go-homedir"
 )
 
 const (
@@ -17,6 +25,7 @@ const (
 type Config struct {
 	Api                   *heroku.Service
 	APIKey                string
+	DebugHTTP             bool
 	Email                 string
 	Headers               http.Header
 	PostAppCreateDelay    int64
@@ -25,19 +34,32 @@ type Config struct {
 	URL                   string
 }
 
-// Client returns a new Config for accessing Heroku.
-func (c *Config) loadAndInitialize() error {
-	var debugHTTP = false
-	if logging.IsDebugOrHigher() {
-		debugHTTP = true
+func (c Config) String() string {
+	return fmt.Sprintf("{APIKey:xxx Email:%s URL:%s Headers:xxx DebugHTTP:%t PostAppCreateDelay:%d PostDomainCreateDelay:%d PostSpaceCreateDelay:%d}",
+		c.Email, c.URL, c.DebugHTTP, c.PostAppCreateDelay, c.PostDomainCreateDelay, c.PostSpaceCreateDelay)
+}
+
+func NewConfig() *Config {
+	config := &Config{
+		Headers:               make(http.Header),
+		PostAppCreateDelay:    DefaultPostAppCreateDelay,
+		PostDomainCreateDelay: DefaultPostDomainCreateDelay,
+		PostSpaceCreateDelay:  DefaultPostSpaceCreateDelay,
 	}
+	if logging.IsDebugOrHigher() {
+		config.DebugHTTP = true
+	}
+	return config
+}
+
+func (c *Config) initializeAPI() (err error) {
 	c.Api = heroku.NewService(&http.Client{
 		Transport: &heroku.Transport{
 			Username:          c.Email,
 			Password:          c.APIKey,
 			UserAgent:         heroku.DefaultUserAgent,
 			AdditionalHeaders: c.Headers,
-			Debug:             debugHTTP,
+			Debug:             c.DebugHTTP,
 			Transport:         heroku.RoundTripWithRetryBackoff{
 				// Configuration fields for ExponentialBackOff
 				// InitialIntervalSeconds: 30,
@@ -52,6 +74,99 @@ func (c *Config) loadAndInitialize() error {
 	c.Api.URL = c.URL
 
 	log.Printf("[INFO] Heroku Client configured for user: %s", c.Email)
+
+	return
+}
+
+func (c *Config) applySchema(d *schema.ResourceData) (err error) {
+	headers := make(map[string]string)
+	if h := d.Get("headers").(string); h != "" {
+		if err = json.Unmarshal([]byte(h), &headers); err != nil {
+			return
+		}
+	}
+
+	for k, v := range headers {
+		c.Headers.Set(k, v)
+	}
+
+	if url, ok := d.GetOk("url"); ok {
+		c.URL = url.(string)
+	}
+
+	if v, ok := d.GetOk("delays"); ok {
+		vL := v.([]interface{})
+		if len(vL) > 1 {
+			return fmt.Errorf("Provider configuration error: only 1 delays config is permitted")
+		}
+		for _, v := range vL {
+			delaysConfig := v.(map[string]interface{})
+			if v, ok := delaysConfig["post_app_create_delay"].(int); ok && v != 0 {
+				c.PostAppCreateDelay = int64(v)
+			}
+			if v, ok := delaysConfig["post_space_create_delay"].(int); ok && v != 0 {
+				c.PostSpaceCreateDelay = int64(v)
+			}
+			if v, ok := delaysConfig["post_domain_create_delay"].(int); ok && v != 0 {
+				c.PostDomainCreateDelay = int64(v)
+			}
+		}
+	}
+
+	return
+}
+
+func (c *Config) applyNetrcFile() error {
+	// Get the netrc file path. If path not shown, then fall back to default netrc path value
+	path := os.Getenv("NETRC_PATH")
+
+	if path == "" {
+		filename := ".netrc"
+		if runtime.GOOS == "windows" {
+			filename = "_netrc"
+		}
+
+		var err error
+		path, err = homedir.Expand("~/" + filename)
+		if err != nil {
+			return err
+		}
+	}
+
+	// If the file is not a file, then do nothing
+	if fi, err := os.Stat(path); err != nil {
+		// File doesn't exist, do nothing
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		// Some other error!
+		return err
+	} else if fi.IsDir() {
+		// File is directory, ignore
+		return nil
+	}
+
+	// Load up the netrc file
+	net, err := netrc.ParseFile(path)
+	if err != nil {
+		return fmt.Errorf("error parsing netrc file at %q: %s", path, err)
+	}
+
+	u, err := url.Parse(c.URL)
+	if err != nil {
+		return err
+	}
+
+	machine := net.FindMachine(u.Host)
+	if machine == nil {
+		// Machine not found, no problem
+		return nil
+	}
+
+	// Set the user/api key/headers
+	c.Email = machine.Login
+	c.APIKey = machine.Password
 
 	return nil
 }

--- a/heroku/config.go
+++ b/heroku/config.go
@@ -101,13 +101,13 @@ func (c *Config) applySchema(d *schema.ResourceData) (err error) {
 		}
 		for _, v := range vL {
 			delaysConfig := v.(map[string]interface{})
-			if v, ok := delaysConfig["post_app_create_delay"].(int); ok && v != 0 {
+			if v, ok := delaysConfig["post_app_create_delay"].(int); ok {
 				c.PostAppCreateDelay = int64(v)
 			}
-			if v, ok := delaysConfig["post_space_create_delay"].(int); ok && v != 0 {
+			if v, ok := delaysConfig["post_space_create_delay"].(int); ok {
 				c.PostSpaceCreateDelay = int64(v)
 			}
-			if v, ok := delaysConfig["post_domain_create_delay"].(int); ok && v != 0 {
+			if v, ok := delaysConfig["post_domain_create_delay"].(int); ok {
 				c.PostDomainCreateDelay = int64(v)
 			}
 		}

--- a/heroku/config.go
+++ b/heroku/config.go
@@ -9,9 +9,9 @@ import (
 )
 
 const (
-	DefaultPostAppCreateDelay    = int64(5)
-	DefaultPostSpaceCreateDelay  = int64(5)
-	DefaultPostDomainCreateDelay = int64(5)
+	DefaultPostAppCreateDelay    = int64(10)
+	DefaultPostSpaceCreateDelay  = int64(10)
+	DefaultPostDomainCreateDelay = int64(10)
 )
 
 type Config struct {

--- a/heroku/helper.go
+++ b/heroku/helper.go
@@ -3,9 +3,11 @@ package heroku
 import (
 	"context"
 	"fmt"
+	"log"
+	"strings"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/heroku/heroku-go/v3"
-	"log"
 )
 
 // getAppName extracts the app attribute generically from a Heroku resource.
@@ -40,4 +42,19 @@ func doesHerokuAppExist(appName string, client *heroku.Service) (*heroku.App, er
 		return nil, fmt.Errorf("[ERROR] Your app does not exist")
 	}
 	return app, nil
+}
+
+func buildCompositeID(a, b string) string {
+	return fmt.Sprintf("%s:%s", a, b)
+}
+
+func parseCompositeID(id string) (p1 string, p2 string, err error) {
+	parts := strings.SplitN(id, ":", 2)
+	if len(parts) == 2 {
+		p1 = parts[0]
+		p2 = parts[1]
+	} else {
+		err = fmt.Errorf("error: Import composite ID requires two parts separated by colon, eg x:y")
+	}
+	return
 }

--- a/heroku/provider.go
+++ b/heroku/provider.go
@@ -44,7 +44,7 @@ func Provider() terraform.ResourceProvider {
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("HEROKU_API_URL", heroku.DefaultURL),
 			},
-			"api": {
+			"delays": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
@@ -142,7 +142,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		config.APIKey = apiKey.(string)
 	}
 
-	err = applyAPIConfig(d, &config)
+	err = applyDelayConfig(d, &config)
 
 	log.Println("[INFO] Initializing Heroku client")
 	if err := config.loadAndInitialize(); err != nil {
@@ -152,8 +152,8 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	return &config, nil
 }
 
-func applyAPIConfig(d *schema.ResourceData, config *Config) error {
-	if v, ok := d.GetOk("api"); ok {
+func applyDelayConfig(d *schema.ResourceData, config *Config) error {
+	if v, ok := d.GetOk("delays"); ok {
 		vL := v.([]interface{})
 		if len(vL) > 1 {
 			return fmt.Errorf("Provider configuration error: only 1 api config is permitted")

--- a/heroku/provider.go
+++ b/heroku/provider.go
@@ -1,22 +1,14 @@
 package heroku
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
-	"net/http"
-	"net/url"
 	"strings"
 
-	"os"
-	"runtime"
-
-	"github.com/bgentry/go-netrc/netrc"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/hashicorp/terraform/terraform"
 	heroku "github.com/heroku/heroku-go/v3"
-	"github.com/mitchellh/go-homedir"
 )
 
 // Provider returns a terraform.ResourceProvider.
@@ -109,31 +101,18 @@ func Provider() terraform.ResourceProvider {
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
-	config := Config{}
+	log.Println("[INFO] Initializing Heroku provider")
+	config := NewConfig()
 
-	headers := make(map[string]string)
-	if h := d.Get("headers").(string); h != "" {
-		if err := json.Unmarshal([]byte(h), &headers); err != nil {
-			return nil, err
-		}
-	}
-
-	h := make(http.Header)
-	for k, v := range headers {
-		h.Set(k, v)
-	}
-
-	config.Headers = h
-
-	if url, ok := d.GetOk("url"); ok {
-		config.URL = url.(string)
-	}
-
-	err := readNetrcFile(&config)
-	if err != nil {
+	if err := config.applySchema(d); err != nil {
 		return nil, err
 	}
 
+	if err := config.applyNetrcFile(); err != nil {
+		return nil, err
+	}
+
+	//the provider resource schema takes precedence over Netrc
 	if email, ok := d.GetOk("email"); ok {
 		config.Email = email.(string)
 	}
@@ -142,36 +121,13 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		config.APIKey = apiKey.(string)
 	}
 
-	err = applyDelayConfig(d, &config)
-
-	log.Println("[INFO] Initializing Heroku client")
-	if err := config.loadAndInitialize(); err != nil {
+	if err := config.initializeAPI(); err != nil {
 		return nil, err
 	}
 
-	return &config, nil
-}
+	log.Printf("[DEBUG] Heroku provider initialized: %s\n", config)
 
-func applyDelayConfig(d *schema.ResourceData, config *Config) error {
-	if v, ok := d.GetOk("delays"); ok {
-		vL := v.([]interface{})
-		if len(vL) > 1 {
-			return fmt.Errorf("Provider configuration error: only 1 delays config is permitted")
-		}
-		for _, v := range vL {
-			apiConfig := v.(map[string]interface{})
-			if v, ok := apiConfig["post_app_create_delay"].(int); ok && v != 0 {
-				config.PostAppCreateDelay = int64(v)
-			}
-			if v, ok := apiConfig["post_space_create_delay"].(int); ok && v != 0 {
-				config.PostSpaceCreateDelay = int64(v)
-			}
-			if v, ok := apiConfig["post_domain_create_delay"].(int); ok && v != 0 {
-				config.PostDomainCreateDelay = int64(v)
-			}
-		}
-	}
-	return nil
+	return config, nil
 }
 
 func buildCompositeID(a, b string) string {
@@ -187,60 +143,4 @@ func parseCompositeID(id string) (p1 string, p2 string, err error) {
 		err = fmt.Errorf("error: Import composite ID requires two parts separated by colon, eg x:y")
 	}
 	return
-}
-
-// Credit of this method is from https://github.com/Yelp/terraform-provider-signalform
-func readNetrcFile(config *Config) error {
-	// Get the netrc file path. If path not shown, then fall back to default netrc path value
-	path := os.Getenv("NETRC_PATH")
-
-	if path == "" {
-		filename := ".netrc"
-		if runtime.GOOS == "windows" {
-			filename = "_netrc"
-		}
-
-		var err error
-		path, err = homedir.Expand("~/" + filename)
-		if err != nil {
-			return err
-		}
-	}
-
-	// If the file is not a file, then do nothing
-	if fi, err := os.Stat(path); err != nil {
-		// File doesn't exist, do nothing
-		if os.IsNotExist(err) {
-			return nil
-		}
-
-		// Some other error!
-		return err
-	} else if fi.IsDir() {
-		// File is directory, ignore
-		return nil
-	}
-
-	// Load up the netrc file
-	net, err := netrc.ParseFile(path)
-	if err != nil {
-		return fmt.Errorf("error parsing netrc file at %q: %s", path, err)
-	}
-
-	u, err := url.Parse(config.URL)
-	if err != nil {
-		return err
-	}
-
-	machine := net.FindMachine(u.Host)
-	if machine == nil {
-		// Machine not found, no problem
-		return nil
-	}
-
-	// Set the user/api key/headers
-	config.Email = machine.Login
-	config.APIKey = machine.Password
-
-	return nil
 }

--- a/heroku/provider.go
+++ b/heroku/provider.go
@@ -1,9 +1,7 @@
 package heroku
 
 import (
-	"fmt"
 	"log"
-	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -128,19 +126,4 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	log.Printf("[DEBUG] Heroku provider initialized: %s\n", config)
 
 	return config, nil
-}
-
-func buildCompositeID(a, b string) string {
-	return fmt.Sprintf("%s:%s", a, b)
-}
-
-func parseCompositeID(id string) (p1 string, p2 string, err error) {
-	parts := strings.SplitN(id, ":", 2)
-	if len(parts) == 2 {
-		p1 = parts[0]
-		p2 = parts[1]
-	} else {
-		err = fmt.Errorf("error: Import composite ID requires two parts separated by colon, eg x:y")
-	}
-	return
 }

--- a/heroku/provider.go
+++ b/heroku/provider.go
@@ -156,7 +156,7 @@ func applyDelayConfig(d *schema.ResourceData, config *Config) error {
 	if v, ok := d.GetOk("delays"); ok {
 		vL := v.([]interface{})
 		if len(vL) > 1 {
-			return fmt.Errorf("Provider configuration error: only 1 api config is permitted")
+			return fmt.Errorf("Provider configuration error: only 1 delays config is permitted")
 		}
 		for _, v := range vL {
 			apiConfig := v.(map[string]interface{})

--- a/heroku/resource_heroku_app.go
+++ b/heroku/resource_heroku_app.go
@@ -251,12 +251,17 @@ func resourceHerokuAppImport(d *schema.ResourceData, m interface{}) ([]*schema.R
 	return []*schema.ResourceData{d}, nil
 }
 
-func switchHerokuAppCreate(d *schema.ResourceData, meta interface{}) error {
+func switchHerokuAppCreate(d *schema.ResourceData, meta interface{}) (err error) {
 	if isOrganizationApp(d) {
-		return resourceHerokuOrgAppCreate(d, meta)
+		err = resourceHerokuOrgAppCreate(d, meta)
+	} else {
+		err = resourceHerokuAppCreate(d, meta)
 	}
-
-	return resourceHerokuAppCreate(d, meta)
+	if err == nil {
+		config := meta.(*Config)
+		time.Sleep(time.Duration(config.PostAppCreateDelay) * time.Second)
+	}
+	return
 }
 
 func resourceHerokuAppCreate(d *schema.ResourceData, meta interface{}) error {

--- a/heroku/resource_heroku_domain.go
+++ b/heroku/resource_heroku_domain.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/heroku/heroku-go/v3"
@@ -77,6 +78,8 @@ func resourceHerokuDomainCreate(d *schema.ResourceData, meta interface{}) error 
 	d.Set("cname", do.CName)
 
 	log.Printf("[INFO] Domain ID: %s", d.Id())
+	config := meta.(*Config)
+	time.Sleep(time.Duration(config.PostDomainCreateDelay) * time.Second)
 	return nil
 }
 

--- a/heroku/resource_heroku_space.go
+++ b/heroku/resource_heroku_space.go
@@ -142,6 +142,9 @@ func resourceHerokuSpaceCreate(d *schema.ResourceData, meta interface{}) error {
 		log.Printf("[DEBUG] Set Trusted IP Ranges to %s for Space %s", ips.List(), d.Id())
 	}
 
+	config := meta.(*Config)
+	time.Sleep(time.Duration(config.PostSpaceCreateDelay) * time.Second)
+
 	return resourceHerokuSpaceRead(d, meta)
 }
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -101,8 +101,8 @@ The following arguments are supported:
 
 The nested `delays` block supports the following:
 
-* `post_app_create_delay` - (Optional) The number of seconds to wait after an app is created. Default is to wait 10 seconds.
+* `post_app_create_delay` - (Optional) The number of seconds to wait after an app is created. Default is to wait 5 seconds.
 
-* `post_space_create_delay` - (Optional) The number of seconds to wait after a private space is created. Default is to wait 10 seconds.
+* `post_space_create_delay` - (Optional) The number of seconds to wait after a private space is created. Default is to wait 5 seconds.
 
-* `post_domain_create_delay` - (Optional) The number of seconds to wait after a domain is created. Default is to wait 10 seconds.
+* `post_domain_create_delay` - (Optional) The number of seconds to wait after a domain is created. Default is to wait 5 seconds.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -101,8 +101,8 @@ The following arguments are supported:
 
 The nested `delays` block supports the following:
 
-* `post_app_create_delay` - (Optional) The number of seconds to wait after an app is created. Default is to wait 8 seconds.
+* `post_app_create_delay` - (Optional) The number of seconds to wait after an app is created. Default is to wait 5 seconds.
 
-* `post_space_create_delay` - (Optional) The number of seconds to wait after a private space is created. Default is to wait 8 seconds.
+* `post_space_create_delay` - (Optional) The number of seconds to wait after a private space is created. Default is to wait 5 seconds.
 
-* `post_domain_create_delay` - (Optional) The number of seconds to wait after a domain is created. Default is to wait 8 seconds.
+* `post_domain_create_delay` - (Optional) The number of seconds to wait after a domain is created. Default is to wait 5 seconds.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -41,8 +41,12 @@ precedence, and explained below:
 
 ### Static credentials
 
+<<<<<<< HEAD
 Static credentials can be provided by adding an `email` and `api_key` in-line
 in the Heroku provider block:
+=======
+Static credentials can be provided by adding an `email` and `api_key` in-line in the Heroku provider block:
+>>>>>>> Fix doc formatting
 
 ```hcl
 provider "heroku" {
@@ -52,10 +56,15 @@ provider "heroku" {
 ```
 
 ### Environment variables
+<<<<<<< HEAD
 
 You can provide your credentials via the `HEROKU_EMAIL` and `HEROKU_API_KEY`
 environment variables, representing your Heroku email address and Heroku api
 key, respectively.
+=======
+You can provide your credentials via the `HEROKU_EMAIL` and `HEROKU_API_KEY` environment variables,
+representing your Heroku email address and Heroku api key, respectively.
+>>>>>>> Fix doc formatting
 
 ```hcl
 provider "heroku" {}
@@ -63,13 +72,18 @@ provider "heroku" {}
 
 Usage:
 
+<<<<<<< HEAD
 ```shell
+=======
+```
+>>>>>>> Fix doc formatting
 $ export HEROKU_EMAIL="ops@company.com"
 $ export HEROKU_API_KEY="heroku_api_key"
 $ terraform plan
 ```
 
 ### Netrc
+<<<<<<< HEAD
 
 You can provider your credentials via a `.netrc` file in your home directory.
 This file should be in the following format:
@@ -81,6 +95,17 @@ machine api.heroku.com
 ```
 
 For more information about netrc, please refer to [https://ec.haxx.se/usingcurl-netrc.html](https://ec.haxx.se/usingcurl-netrc.html) 
+=======
+You can provider your credentials via a `.netrc` file in your home directory. This file should be in this format:
+
+ ```
+ machine api.heroku.com
+   login <your_heroku_email>
+   password <your_heroku_api_key>
+ ```
+
+ For more information about netrc, please refer to [https://ec.haxx.se/usingcurl-netrc.html](https://ec.haxx.se/usingcurl-netrc.html)
+>>>>>>> Fix doc formatting
 
 ## Argument Reference
 
@@ -94,6 +119,7 @@ The following arguments are supported:
 
 * `headers` - (Optional) Additional Headers to be sent to Heroku. If not provided,
   it can also be sourced from the `HEROKU_HEADERS` environment variable.
+
 * `delays` - (Optional) A `delays` block (documented below). Only one
   `delays` block may be in the configuration. Delays help mitigate issues with 
   eventual consistency in the Heroku back-end service.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -41,12 +41,8 @@ precedence, and explained below:
 
 ### Static credentials
 
-<<<<<<< HEAD
 Static credentials can be provided by adding an `email` and `api_key` in-line
 in the Heroku provider block:
-=======
-Static credentials can be provided by adding an `email` and `api_key` in-line in the Heroku provider block:
->>>>>>> Fix doc formatting
 
 ```hcl
 provider "heroku" {
@@ -56,15 +52,10 @@ provider "heroku" {
 ```
 
 ### Environment variables
-<<<<<<< HEAD
 
 You can provide your credentials via the `HEROKU_EMAIL` and `HEROKU_API_KEY`
 environment variables, representing your Heroku email address and Heroku api
 key, respectively.
-=======
-You can provide your credentials via the `HEROKU_EMAIL` and `HEROKU_API_KEY` environment variables,
-representing your Heroku email address and Heroku api key, respectively.
->>>>>>> Fix doc formatting
 
 ```hcl
 provider "heroku" {}
@@ -72,18 +63,13 @@ provider "heroku" {}
 
 Usage:
 
-<<<<<<< HEAD
 ```shell
-=======
-```
->>>>>>> Fix doc formatting
 $ export HEROKU_EMAIL="ops@company.com"
 $ export HEROKU_API_KEY="heroku_api_key"
 $ terraform plan
 ```
 
 ### Netrc
-<<<<<<< HEAD
 
 You can provider your credentials via a `.netrc` file in your home directory.
 This file should be in the following format:
@@ -95,17 +81,6 @@ machine api.heroku.com
 ```
 
 For more information about netrc, please refer to [https://ec.haxx.se/usingcurl-netrc.html](https://ec.haxx.se/usingcurl-netrc.html) 
-=======
-You can provider your credentials via a `.netrc` file in your home directory. This file should be in this format:
-
- ```
- machine api.heroku.com
-   login <your_heroku_email>
-   password <your_heroku_api_key>
- ```
-
- For more information about netrc, please refer to [https://ec.haxx.se/usingcurl-netrc.html](https://ec.haxx.se/usingcurl-netrc.html)
->>>>>>> Fix doc formatting
 
 ## Argument Reference
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -94,3 +94,14 @@ The following arguments are supported:
 
 * `headers` - (Optional) Additional Headers to be sent to Heroku. If not provided,
   it can also be sourced from the `HEROKU_HEADERS` environment variable.
+* `delays` - (Optional) A `delays` block (documented below). Only one
+  `delays` block may be in the configuration. Delays help mitigate issues with 
+  eventual consistency in the Heroku back-end service.
+
+The nested `delays` block supports the following:
+
+* `post_app_create_delay` - (Optional) The number of seconds to wait after an app is created. Default is to wait 8 seconds.
+
+* `post_space_create_delay` - (Optional) The number of seconds to wait after a private space is created. Default is to wait 8 seconds.
+
+* `post_domain_create_delay` - (Optional) The number of seconds to wait after a domain is created. Default is to wait 8 seconds.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -101,8 +101,8 @@ The following arguments are supported:
 
 The nested `delays` block supports the following:
 
-* `post_app_create_delay` - (Optional) The number of seconds to wait after an app is created. Default is to wait 5 seconds.
+* `post_app_create_delay` - (Optional) The number of seconds to wait after an app is created. Default is to wait 10 seconds.
 
-* `post_space_create_delay` - (Optional) The number of seconds to wait after a private space is created. Default is to wait 5 seconds.
+* `post_space_create_delay` - (Optional) The number of seconds to wait after a private space is created. Default is to wait 10 seconds.
 
-* `post_domain_create_delay` - (Optional) The number of seconds to wait after a domain is created. Default is to wait 5 seconds.
+* `post_domain_create_delay` - (Optional) The number of seconds to wait after a domain is created. Default is to wait 10 seconds.


### PR DESCRIPTION
This is an implementation proposal based on the discussion in #111, whereby we allow additional configuration to be passed into the provider to help alleviate issues with cedars backend eventual consistency with regards to app, spaces, and domain creation.

```hcl
provider "heroku" {
  "delays" : {
     post_app_create_delay = 15
     post_domain_create_delay = 12
     post_space_create_delay = 20  
  }
}
```

Naturally a user *can* do something like: 

```hcl
resource "heroku_app" "default" {
  provisioner "local-exec" {
    command = "sleep 15"
  }
}
```

But this ends up being littered across users HCL files.  When this issue is resolved in the Heroku platform this can be removed or become a no-op. 