### PR TITLE
fix bad formatting in docs

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -8,9 +8,9 @@ description: |-
 
 # Heroku Provider
 
-The Heroku provider is used to interact with the
-resources supported by Heroku. The provider needs to be configured
-with the proper credentials before it can be used.
+The Heroku provider is used to interact with the resources supported by
+Heroku. The provider needs to be configured with the proper credentials
+before it can be used.
 
 Use the navigation to the left to read about the available resources.
 
@@ -30,15 +30,20 @@ resource "heroku_app" "default" {
 ```
 
 ## Authentication
-The Heroku provider offers a flexible means of providing credentials for authentication.
-The following methods are supported, listed in order precedence, and explained below:
+
+The Heroku provider offers a flexible means of providing credentials for
+authentication. The following methods are supported, listed in order
+precedence, and explained below:
+
 - Static credentials
 - Environment variables
 - Netrc
 
 ### Static credentials
 
-Static credentials can be provided by adding an `email` and `api_key` in-line in the Heroku provider block:
+Static credentials can be provided by adding an `email` and `api_key` in-line
+in the Heroku provider block:
+
 ```hcl
 provider "heroku" {
   email   = "ops@company.com"
@@ -47,34 +52,45 @@ provider "heroku" {
 ```
 
 ### Environment variables
-You can provide your credentials via the `HEROKU_EMAIL` and `HEROKU_API_KEY` environment variables,
-representing your Heroku email address and Heroku api key, respectively.
+
+You can provide your credentials via the `HEROKU_EMAIL` and `HEROKU_API_KEY`
+environment variables, representing your Heroku email address and Heroku api
+key, respectively.
+
 ```hcl
 provider "heroku" {}
 ```
 
 Usage:
-```
+
+```shell
 $ export HEROKU_EMAIL="ops@company.com"
 $ export HEROKU_API_KEY="heroku_api_key"
 $ terraform plan
 ```
 
 ### Netrc
-You can provider your credentials via a `.netrc` file in your home directory. This file should be in this format:
- ```
- machine api.heroku.com
-   login <your_heroku_email>
-   password <your_heroku_api_key>
- ```
- For more information about netrc, please refer to [https://ec.haxx.se/usingcurl-netrc.html](https://ec.haxx.se/usingcurl-netrc.html)
+
+You can provider your credentials via a `.netrc` file in your home directory.
+This file should be in the following format:
+
+```
+machine api.heroku.com
+  login <your_heroku_email>
+  password <your_heroku_api_key>
+```
+
+For more information about netrc, please refer to [https://ec.haxx.se/usingcurl-netrc.html](https://ec.haxx.se/usingcurl-netrc.html) 
 
 ## Argument Reference
 
 The following arguments are supported:
+
 * `api_key` - (Required) Heroku API token. It must be provided, but it can also
   be sourced from the `HEROKU_API_KEY` environment variable.
+
 * `email` - (Required) Email to be notified by Heroku. It must be provided, but
   it can also be sourced from the `HEROKU_EMAIL` environment variable.
+
 * `headers` - (Optional) Additional Headers to be sent to Heroku. If not provided,
   it can also be sourced from the `HEROKU_HEADERS` environment variable.

--- a/website/docs/r/cert.html.markdown
+++ b/website/docs/r/cert.html.markdown
@@ -51,4 +51,8 @@ The following attributes are exported:
 
 ## Importing
 
-When importing a Heroku cert resource, the ID must be built using the app name colon the unique ID from the Heroku API. For an app named `production-api` with a certificate ID of `b85d9224-310b-409b-891e-c903f5a40568`, you would import it as: `$ terraform import heroku_cert.production_api production-api:b85d9224-310b-409b-891e-c903f5a40568`.
+When importing a Heroku cert resource, the ID must be built using the app name colon the unique ID from the Heroku API. For an app named `production-api` with a certificate ID of `b85d9224-310b-409b-891e-c903f5a40568`, you would import it as: 
+
+```
+$ terraform import heroku_cert.production_api production-api:b85d9224-310b-409b-891e-c903f5a40568
+```

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -43,4 +43,8 @@ The following attributes are exported:
 
 ## Importing
 
-When importing a Heroku domain resource, the ID must be built using the app name colon the unique ID from the Heroku API. For an app named `production-api` with a domain ID of `b85d9224-310b-409b-891e-c903f5a40568`, you would import it as: `$ terraform import heroku_domain.production_api production-api:b85d9224-310b-409b-891e-c903f5a40568`.
+When importing a Heroku domain resource, the ID must be built using the app name colon the unique ID from the Heroku API. For an app named `production-api` with a domain ID of `b85d9224-310b-409b-891e-c903f5a40568`, you would import it as: 
+
+```
+$ terraform import heroku_domain.production_api production-api:b85d9224-310b-409b-891e-c903f5a40568
+```

--- a/website/docs/r/drain.html.markdown
+++ b/website/docs/r/drain.html.markdown
@@ -35,4 +35,8 @@ The following attributes are exported:
 
 ## Importing
 
-When importing a Heroku drain resource, the ID must be built using the app name colon the unique ID from the Heroku API. For an app named `production-api` with a drain ID of `b85d9224-310b-409b-891e-c903f5a40568`, you would import it as: `$ terraform import heroku_drain.production_api production-api:b85d9224-310b-409b-891e-c903f5a40568`
+When importing a Heroku drain resource, the ID must be built using the app name colon the unique ID from the Heroku API. For an app named `production-api` with a drain ID of `b85d9224-310b-409b-891e-c903f5a40568`, you would import it as: 
+
+```
+$ terraform import heroku_drain.production_api production-api:b85d9224-310b-409b-891e-c903f5a40568
+```

--- a/website/docs/r/formation.html.markdown
+++ b/website/docs/r/formation.html.markdown
@@ -48,19 +48,23 @@ resource "heroku_formation" "foobar-web" {
 ```
 
 ## Argument Reference
+
 * `app` - (Required) The name of the application
 * `type` - (Required) type of process such as "web"
 * `quantity` - (Required) number of processes to maintain
 * `size` - (Required) dyno size (Example: “standard-1X”). Capitalization does not matter.
 
 ## Attributes Reference
+
 The following attributes are exported:
+
 * `id` - The ID of the formation
 
 ## Import
 Existing formations can be imported using the combination of the application name, a colon, and the formation's type.
 
 For example:
+
 ```
 $ terraform import heroku_formation.foobar-web foobar:web
 ```

--- a/website/docs/r/slug.html.markdown
+++ b/website/docs/r/slug.html.markdown
@@ -107,6 +107,7 @@ The following attributes are exported:
 Existing slugs can be imported using the combination of the application name, a colon, and the slug ID.
 
 For example:
+
 ```
 $ terraform import heroku_slug.foobar bazbux:4f1db8ef-ed5c-4c42-a3d6-3c28262d5abc
 ```

--- a/website/docs/r/space_app_access.markdown
+++ b/website/docs/r/space_app_access.markdown
@@ -42,3 +42,13 @@ The following arguments are supported:
 * `space` - (Required) The name of the space.
 * `email` - (Required) The email of the team member to set permissions for.
 * `permissions` - (Required) The permissions to grant the team member for the space. Currently `create_apps` is the only supported permission. If not provided the member will have no permissions to the space. Members with admin role will always have `create_apps` permissions, which cannot be removed.
+
+## Importing
+
+Existing slugs can be imported using the combination of the space name, a colon, and the member email.
+
+For example:
+
+```
+$ terraform import heroku_space_app_access.member1 my-space:member1@foobar.com
+```


### PR DESCRIPTION
Hrmm, looks like the index formatting went bad in the index and a few other spots: https://www.terraform.io/docs/providers/heroku/index.html 😢 

To test docs/formatting, you can run this locally:

```
$ make website
```