### PR TITLE
Allow setting URL

### DIFF
--- a/heroku/config.go
+++ b/heroku/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	Email   string
 	APIKey  string
 	Headers http.Header
+	URL     string
 
 	Api *heroku.Service
 }
@@ -38,6 +39,8 @@ func (c *Config) loadAndInitialize() error {
 			},
 		},
 	})
+
+	c.Api.URL = c.URL
 
 	log.Printf("[INFO] Heroku Client configured for user: %s", c.Email)
 


### PR DESCRIPTION
Heroku has multiple environments and it would be great if we could use Terraform to manage resources in these.

I decided to not document usage in the website/docs/index.html.markdown file because of the limited utility. Let me know if I should.