### PR TITLE
📚 Build resource doc fixups

### DIFF
--- a/website/docs/r/build.html.markdown
+++ b/website/docs/r/build.html.markdown
@@ -15,7 +15,7 @@ Either a URL or local path, pointing to a [tarball](https://en.wikipedia.org/wik
 
 This resource waits until the [build](https://devcenter.heroku.com/articles/build-and-release-using-the-api) & [release](https://devcenter.heroku.com/articles/release-phase) completes.
 
-If build fails, the error will contain a URL to view the build log. `curl "https://the-long-log-url-in-the-error"`.
+If the build fails, the error will contain a URL to view the build log. `curl "https://the-long-log-url-in-the-error"`.
 
 To start the app from a successful build, use a [Formation resource](formation.html) to specify the process, dyno size, and dyno quantity.
 

--- a/website/heroku.erb
+++ b/website/heroku.erb
@@ -54,6 +54,10 @@
                       <a href="/docs/providers/heroku/r/app_release.html">heroku_app_release</a>
                     </li>
 
+                    <li<%= sidebar_current("docs-heroku-resource-build") %>>
+                      <a href="/docs/providers/heroku/r/build.html">heroku_build</a>
+                    </li>
+
                     <li<%= sidebar_current("docs-heroku-resource-cert") %>>
                       <a href="/docs/providers/heroku/r/cert.html">heroku_cert</a>
                     </li>


### PR DESCRIPTION
* add `heroku_build` to sidebar navigation (where did it go!?)
* add & distinguish Container/Docker builds from Buildpack builds
* minor formatting/style