### PR TITLE
add provider delay config for app delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 ## 1.7.1 (Unreleased)
+
+FEATURES:
+
+IMPROVEMENTS:
+* Add configurable delay for post app deletion [#158](https://github.com/terraform-providers/terraform-provider-heroku/pull/158)
+
+BUG FIXES:
+
 ## 1.7.0 (December 14, 2018)
 
 FEATURES:

--- a/heroku/config.go
+++ b/heroku/config.go
@@ -37,8 +37,8 @@ type Config struct {
 }
 
 func (c Config) String() string {
-	return fmt.Sprintf("{APIKey:xxx Email:%s URL:%s Headers:xxx DebugHTTP:%t PostAppCreateDelay:%d PostDomainCreateDelay:%d PostSpaceCreateDelay:%d}",
-		c.Email, c.URL, c.DebugHTTP, c.PostAppCreateDelay, c.PostDomainCreateDelay, c.PostSpaceCreateDelay)
+	return fmt.Sprintf("{APIKey:xxx Email:%s URL:%s Headers:xxx DebugHTTP:%t PostAppCreateDelay:%d PostAppDeleteDelay:%d PostDomainCreateDelay:%d PostSpaceCreateDelay:%d}",
+		c.Email, c.URL, c.DebugHTTP, c.PostAppCreateDelay, c.PostAppDeleteDelay, c.PostDomainCreateDelay, c.PostSpaceCreateDelay)
 }
 
 func NewConfig() *Config {

--- a/heroku/config.go
+++ b/heroku/config.go
@@ -18,6 +18,7 @@ import (
 
 const (
 	DefaultPostAppCreateDelay    = int64(5)
+	DefaultPostAppDeleteDelay    = int64(5)
 	DefaultPostSpaceCreateDelay  = int64(5)
 	DefaultPostDomainCreateDelay = int64(5)
 )
@@ -29,6 +30,7 @@ type Config struct {
 	Email                 string
 	Headers               http.Header
 	PostAppCreateDelay    int64
+	PostAppDeleteDelay    int64
 	PostDomainCreateDelay int64
 	PostSpaceCreateDelay  int64
 	URL                   string
@@ -43,6 +45,7 @@ func NewConfig() *Config {
 	config := &Config{
 		Headers:               make(http.Header),
 		PostAppCreateDelay:    DefaultPostAppCreateDelay,
+		PostAppDeleteDelay:    DefaultPostAppDeleteDelay,
 		PostDomainCreateDelay: DefaultPostDomainCreateDelay,
 		PostSpaceCreateDelay:  DefaultPostSpaceCreateDelay,
 	}
@@ -103,6 +106,9 @@ func (c *Config) applySchema(d *schema.ResourceData) (err error) {
 			delaysConfig := v.(map[string]interface{})
 			if v, ok := delaysConfig["post_app_create_delay"].(int); ok {
 				c.PostAppCreateDelay = int64(v)
+			}
+			if v, ok := delaysConfig["post_app_delete_delay"].(int); ok {
+				c.PostAppDeleteDelay = int64(v)
 			}
 			if v, ok := delaysConfig["post_space_create_delay"].(int); ok {
 				c.PostSpaceCreateDelay = int64(v)

--- a/heroku/provider.go
+++ b/heroku/provider.go
@@ -46,6 +46,12 @@ func Provider() terraform.ResourceProvider {
 							Default:      DefaultPostAppCreateDelay,
 							ValidateFunc: validation.IntAtLeast(0),
 						},
+						"post_app_delete_delay": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      DefaultPostAppDeleteDelay,
+							ValidateFunc: validation.IntAtLeast(0),
+						},
 						"post_space_create_delay": {
 							Type:         schema.TypeInt,
 							Optional:     true,

--- a/heroku/resource_heroku_app.go
+++ b/heroku/resource_heroku_app.go
@@ -545,6 +545,10 @@ func resourceHerokuAppDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId("")
+
+	config := meta.(*Config)
+	time.Sleep(time.Duration(config.PostAppDeleteDelay) * time.Second)
+
 	return nil
 }
 

--- a/heroku/resource_heroku_space.go
+++ b/heroku/resource_heroku_space.go
@@ -142,9 +142,6 @@ func resourceHerokuSpaceCreate(d *schema.ResourceData, meta interface{}) error {
 		log.Printf("[DEBUG] Set Trusted IP Ranges to %s for Space %s", ips.List(), d.Id())
 	}
 
-	config := meta.(*Config)
-	time.Sleep(time.Duration(config.PostSpaceCreateDelay) * time.Second)
-
 	return resourceHerokuSpaceRead(d, meta)
 }
 


### PR DESCRIPTION
This is a continuation of #142 to add an additional `post_app_delete_delay` to address #123.

```hcl
provider "heroku" {
  "delays"  {
     post_app_delete_delay = 10  
  }
}
```