### PR TITLE
Identify Terraform API requests via user-agent header

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,7 +14,7 @@ test: fmtcheck
 		xargs -t -n4 go test -v $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m -ldflags="-X=github.com/terraform-providers/terraform-provider-heroku/version.ProviderVersion=acc"
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m -ldflags="-X=github.com/terraform-providers/terraform-provider-heroku/version.ProviderVersion=test"
 
 vet:
 	@echo "go vet ."
@@ -60,4 +60,3 @@ endif
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
 .PHONY: build test testacc vet fmt fmtcheck errcheck vendor-status test-compile website website-test
-

--- a/heroku/config.go
+++ b/heroku/config.go
@@ -55,9 +55,10 @@ func NewConfig() *Config {
 func (c *Config) initializeAPI() (err error) {
 	c.Api = heroku.NewService(&http.Client{
 		Transport: &heroku.Transport{
-			Username:          c.Email,
-			Password:          c.APIKey,
-			UserAgent:         heroku.DefaultUserAgent,
+			Username: c.Email,
+			Password: c.APIKey,
+			UserAgent: fmt.Sprintf("terraform-provider-heroku (%s)",
+				heroku.DefaultUserAgent),
 			AdditionalHeaders: c.Headers,
 			Debug:             c.DebugHTTP,
 			Transport:         heroku.RoundTripWithRetryBackoff{

--- a/heroku/config.go
+++ b/heroku/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	heroku "github.com/heroku/heroku-go/v3"
 	homedir "github.com/mitchellh/go-homedir"
+	"github.com/terraform-providers/terraform-provider-heroku/version"
 )
 
 const (
@@ -57,8 +58,8 @@ func (c *Config) initializeAPI() (err error) {
 		Transport: &heroku.Transport{
 			Username: c.Email,
 			Password: c.APIKey,
-			UserAgent: fmt.Sprintf("%s terraform-provider-heroku",
-				heroku.DefaultUserAgent),
+			UserAgent: fmt.Sprintf("%s terraform-provider-heroku/%s",
+				heroku.DefaultUserAgent, version.ProviderVersion),
 			AdditionalHeaders: c.Headers,
 			Debug:             c.DebugHTTP,
 			Transport:         heroku.RoundTripWithRetryBackoff{

--- a/heroku/config.go
+++ b/heroku/config.go
@@ -57,7 +57,7 @@ func (c *Config) initializeAPI() (err error) {
 		Transport: &heroku.Transport{
 			Username: c.Email,
 			Password: c.APIKey,
-			UserAgent: fmt.Sprintf("terraform-provider-heroku (%s)",
+			UserAgent: fmt.Sprintf("terraform-provider-heroku %s",
 				heroku.DefaultUserAgent),
 			AdditionalHeaders: c.Headers,
 			Debug:             c.DebugHTTP,

--- a/heroku/config.go
+++ b/heroku/config.go
@@ -57,7 +57,7 @@ func (c *Config) initializeAPI() (err error) {
 		Transport: &heroku.Transport{
 			Username: c.Email,
 			Password: c.APIKey,
-			UserAgent: fmt.Sprintf("terraform-provider-heroku %s",
+			UserAgent: fmt.Sprintf("%s terraform-provider-heroku",
 				heroku.DefaultUserAgent),
 			AdditionalHeaders: c.Headers,
 			Debug:             c.DebugHTTP,


### PR DESCRIPTION
In order to facilitate Heroku's desire to observe how tools such as Terraform are used with the platform, set a custom "User-Agent" value for this Terraform provider.

Currently, requests to the Heroku API use the [default HTTP "User-Agent" header from heroku-go](https://github.com/heroku/heroku-go/blob/master/v3/heroku.go#L29), such as:

```
heroku/v3 (linux; amd64)
```
 
This pull request simply will set a custom value to self-identify, and it includes heroku-go's original value:

```
heroku/v3 (linux; amd64) terraform-provider-heroku/v1.7.1
```

Example provider request header:

```
GET /apps/tftest-9yz1nyjtsl/builds/093ad1ad-3f8c-4f65-9f6e-5c73d488753e HTTP/1.1
Host: api.heroku.com
User-Agent: heroku/v3 (darwin; amd64) terraform-provider-heroku/v1.7.1
Accept: application/vnd.heroku+json; version=3
Authorization: Basic xxxxx
Request-Id: 1f0c1bfc-2da7-4b6f-b643-246d7422b66a
Accept-Encoding: gzip
```