### PR TITLE
make provider version available at runtime

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,7 +14,7 @@ test: fmtcheck
 		xargs -t -n4 go test -v $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m -ldflags="-X=github.com/terraform-providers/terraform-provider-heroku/version.ProviderVersion=acc"
 
 vet:
 	@echo "go vet ."

--- a/heroku/helper.go
+++ b/heroku/helper.go
@@ -7,7 +7,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/heroku/heroku-go/v3"
+	heroku "github.com/heroku/heroku-go/v3"
+	"github.com/terraform-providers/terraform-provider-heroku/version"
 )
 
 // getAppName extracts the app attribute generically from a Heroku resource.
@@ -57,4 +58,8 @@ func parseCompositeID(id string) (p1 string, p2 string, err error) {
 		err = fmt.Errorf("error: Import composite ID requires two parts separated by colon, eg x:y")
 	}
 	return
+}
+
+func providerVersion() string {
+	return version.ProviderVersion
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+//Cribbed from
+//https://github.com/terraform-providers/terraform-provider-azurerm/tree/master/version
+//This takes advantage of a new build flag populating the binary version of the
+//provider, for example:
+//-ldflags="-X=github.com/terraform-providers/terraform-provider-heroku/version.ProviderVersion=x.x.x"
+
+var (
+	// ProviderVersion is set during the release process to the release version of the binary, and
+	// set to acc during tests.
+	ProviderVersion = "dev"
+)


### PR DESCRIPTION
Make provider version available at runtime for #161 

Cribbed from https://github.com/terraform-providers/terraform-provider-azurerm/tree/master/version

This takes advantage of a build flag populating the binary version of the provider, for example:

```
-ldflags="-X=github.com/terraform-providers/terraform-provider-heroku/version.ProviderVersion=x.x.x"
```

Thanks to @tombuildsstuff for the tip!
