### PR TITLE
New Heroku App attribute: sensitive_config_vars

### DIFF
--- a/heroku/resource_heroku_app_test.go
+++ b/heroku/resource_heroku_app_test.go
@@ -362,6 +362,27 @@ func TestAccHerokuApp_SensitiveConfigVars(t *testing.T) {
 						"heroku_app.foobar", "sensitive_config_vars.0.PRIVATE_KEY", "it is a secret"),
 				),
 			},
+			{
+				Config: testAccCheckHerokuAppConfig_SensitiveUpdate(appName, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHerokuAppExists("heroku_app.foobar", &app),
+					resource.TestCheckResourceAttr(
+						"heroku_app.foobar", "config_vars.0.FOO", "bar1"),
+					resource.TestCheckResourceAttr(
+						"heroku_app.foobar", "sensitive_config_vars.0.PRIVATE_KEY", "it is a secret1"),
+				),
+			},
+
+			{
+				Config: testAccCheckHerokuAppConfig_SensitiveUpdate_Swap(appName, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHerokuAppExists("heroku_app.foobar", &app),
+					resource.TestCheckResourceAttr(
+						"heroku_app.foobar", "sensitive_config_vars.0.PRIVATE_KEY", "it is a secret1"),
+					resource.TestCheckResourceAttr(
+						"heroku_app.foobar", "sensitive_config_vars.0.FOO", "bar1"),
+				),
+			},
 		},
 	})
 }
@@ -837,6 +858,43 @@ resource "heroku_app" "foobar" {
 
   sensitive_config_vars = {
     PRIVATE_KEY = "it is a secret"
+  }
+}`, appName, org)
+}
+
+func testAccCheckHerokuAppConfig_SensitiveUpdate(appName, org string) string {
+	return fmt.Sprintf(`
+resource "heroku_app" "foobar" {
+  name   = "%s"
+  region = "us"
+  acm = false
+  organization = {
+    name = "%s"
+  }
+
+  config_vars = {
+    FOO = "bar1"
+  }
+
+  sensitive_config_vars = {
+    PRIVATE_KEY = "it is a secret1"
+  }
+}`, appName, org)
+}
+
+func testAccCheckHerokuAppConfig_SensitiveUpdate_Swap(appName, org string) string {
+	return fmt.Sprintf(`
+resource "heroku_app" "foobar" {
+  name   = "%s"
+  region = "us"
+  acm = false
+  organization = {
+    name = "%s"
+  }
+
+  sensitive_config_vars = {
+    FOO = "bar1"
+    PRIVATE_KEY = "it is a secret1"
   }
 }`, appName, org)
 }

--- a/heroku/resource_heroku_app_test.go
+++ b/heroku/resource_heroku_app_test.go
@@ -378,6 +378,8 @@ func TestAccHerokuApp_SensitiveConfigVars(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAppExists("heroku_app.foobar", &app),
 					resource.TestCheckResourceAttr(
+						"heroku_app.foobar", "config_vars.0.WIDGETS", "fake"),
+					resource.TestCheckResourceAttr(
 						"heroku_app.foobar", "sensitive_config_vars.0.PRIVATE_KEY", "it is a secret1"),
 					resource.TestCheckResourceAttr(
 						"heroku_app.foobar", "sensitive_config_vars.0.FOO", "bar1"),
@@ -890,6 +892,10 @@ resource "heroku_app" "foobar" {
   acm = false
   organization = {
     name = "%s"
+  }
+
+  config_vars = {
+    WIDGETS = "fake"
   }
 
   sensitive_config_vars = {

--- a/website/docs/r/app.html.markdown
+++ b/website/docs/r/app.html.markdown
@@ -65,6 +65,11 @@ The `organization` block supports:
 * `locked` (boolean)
 * `personal` (boolean)
 
+~> **NOTE:** Removing an entire `config_vars` or `sensitive_config_vars` block from a
+configuration will not actually remove the vars on the remote resource.
+This is especially important if you are migrating all `config_vars` to `sensitive_config_vars`.
+Leave the empty `config_vars` or `sensitive_config_vars` block in place to remove previously defined vars.
+
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/docs/r/app.html.markdown
+++ b/website/docs/r/app.html.markdown
@@ -45,6 +45,11 @@ The following arguments are supported:
      variables, but rather variables you want present. That is, other
      configuration variables set externally won't be removed by Terraform
      if they aren't present in this list.
+* `sensitive_config_vars` - (Optional) This argument is the same as `config_vars`.
+     The main difference between the two is when `sensitive_config_vars` outputs
+     are displayed on-screen following a terraform apply or terraform refresh,
+     they are redacted, with <sensitive> displayed in place of their value.
+     It is recommended to put private keys, passwords, etc in this argument.
 * `space` - (Optional) The name of a private space to create the app in.
 * `internal_routing` - (Optional) If true, the application will be routable
   only internally in a private space. This option is only available for apps


### PR DESCRIPTION
Resolves #72

Continuing from #101, this issue/PR will introduce a `sensitive_config_vars` attribute to the `heroku_app` resource. This will allow users to add in passwords/tokens/secrets into their .tf files without risking it being exposed in CI builds.

Sample HCL:
```
resource "heroku_app" "foobar" {
  name   = "foobar"
  region = "us"

  config_vars {
    RAILS_ENV = "staging"
  }
  
  sensitive_config_vars {
    DATABASE_URL = "postgres://user:password@some-host.com:1234"
  }
}
```