### PR TITLE
upgrade heroku-go

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -327,11 +327,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:7c79c523059440ed7901f5f815b5d359dd5e080d05d92ae31433273aead21ee6"
+  digest = "1:507e57ad266c0e496705e5bad4dc8665327dfda899e12b96d836d128f1a09544"
   name = "github.com/heroku/heroku-go"
   packages = ["v3"]
   pruneopts = "UT"
-  revision = "3b96879aa0a537cdfabc258cd8a13bc079d06801"
+  revision = "ad17585a922f269c393cbccf2e0cf81eb8d2e431"
 
 [[projects]]
   digest = "1:e22af8c7518e1eab6f2eab2b7d7558927f816262586cd6ed9f349c97a6c285c4"

--- a/heroku/resource_heroku_build.go
+++ b/heroku/resource_heroku_build.go
@@ -168,15 +168,17 @@ func resourceHerokuBuildCreate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("buildpacks"); ok {
 		var buildpacks []*struct {
-			URL *string `json:"url,omitempty" url:"url,omitempty,key"`
+			Name *string `json:"name,omitempty" url:"name,omitempty,key"` // Buildpack Registry name of the buildpack for the app
+			URL  *string `json:"url,omitempty" url:"url,omitempty,key"`   // the URL of the buildpack for the app
 		}
 		buildpacksArg := v.([]interface{})
 		for _, buildpack := range buildpacksArg {
 			b := buildpack.(string)
 			buildpacks = append(buildpacks, &struct {
-				URL *string `json:"url,omitempty" url:"url,omitempty,key"`
+				Name *string `json:"name,omitempty" url:"name,omitempty,key"` // Buildpack Registry name of the buildpack for the app
+				URL  *string `json:"url,omitempty" url:"url,omitempty,key"`   // the URL of the buildpack for the app
 			}{
-				URL: &b,
+				URL: &b, // This may cause problems using Buildpack Registry values, may need to expand this.
 			})
 		}
 		opts.Buildpacks = buildpacks

--- a/vendor/github.com/heroku/heroku-go/v3/schema.json
+++ b/vendor/github.com/heroku/heroku-go/v3/schema.json
@@ -489,6 +489,48 @@
                   "$ref": "#/definitions/organization/definitions/name"
                 }
               }
+            },
+            "owner": {
+              "description": "entity that owns this identity provider",
+              "properties": {
+                "id": {
+                  "description": "unique identifier of the owner",
+                  "example": "01234567-89ab-cdef-0123-456789abcdef",
+                  "format": "uuid",
+                  "readOnly": true,
+                  "type": [
+                    "string"
+                  ]
+                },
+                "name": {
+                  "description": "name of the owner",
+                  "example": "acme",
+                  "readOnly": true,
+                  "type": [
+                    "string"
+                  ]
+                },
+                "type": {
+                  "description": "type of the owner",
+                  "enum": [
+                    "team",
+                    "enterprise-account"
+                  ],
+                  "example": "team",
+                  "readOnly": true,
+                  "type": [
+                    "string"
+                  ]
+                }
+              },
+              "readOnly": false,
+              "required": [
+                "id",
+                "type"
+              ],
+              "type": [
+                "object"
+              ]
             }
           },
           "type": [
@@ -661,6 +703,15 @@
             "null",
             "string"
           ]
+        },
+        "log_input_url": {
+          "description": "URL for add-on partners to write to an add-on's logs",
+          "example": "https://token:t.abcdef12-3456-7890-abcd-ef1234567890@1.us.logplex.io/logs",
+          "type": [
+            "null",
+            "string"
+          ],
+          "readOnly": true
         }
       },
       "links": [
@@ -774,6 +825,40 @@
             "$ref": "#/definitions/add-on-attachment"
           },
           "title": "Info by App"
+        },
+        {
+          "description": "Resolve an add-on attachment from a name, optionally passing an app name. If there are matches it returns at least one add-on attachment (exact match) or many.",
+          "href": "/actions/addon-attachments/resolve",
+          "method": "POST",
+          "rel": "resolve",
+          "schema": {
+            "properties": {
+              "addon_attachment": {
+                "$ref": "#/definitions/add-on-attachment/definitions/name"
+              },
+              "app": {
+                "$ref": "#/definitions/app/definitions/name"
+              },
+              "addon_service": {
+                "$ref": "#/definitions/add-on-service/definitions/name"
+              }
+            },
+            "required": [
+              "addon_attachment"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on-attachment"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "Resolution"
         }
       ],
       "properties": {
@@ -844,6 +929,9 @@
         },
         "web_url": {
           "$ref": "#/definitions/add-on-attachment/definitions/web_url"
+        },
+        "log_input_url": {
+          "$ref": "#/definitions/add-on-attachment/definitions/log_input_url"
         }
       }
     },
@@ -1574,6 +1662,23 @@
             "integer"
           ]
         },
+        "config": {
+          "additionalProperties": false,
+          "description": "custom add-on provisioning options",
+          "example": {
+            "db-version": "1.2.3"
+          },
+          "patternProperties": {
+            "^\\w+$": {
+              "type": [
+                "string"
+              ]
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
         "config_vars": {
           "description": "config vars exposed to the owning app by this add-on",
           "example": [
@@ -1591,7 +1696,7 @@
           ]
         },
         "confirm": {
-          "description": "name of owning app for confirmation",
+          "description": "name of billing entity for confirmation",
           "example": "example",
           "type": [
             "string"
@@ -1721,35 +1826,26 @@
                 "example": {
                   "name": "DATABASE_FOLLOWER"
                 },
-                "name": {
-                  "$ref": "#/definitions/add-on-attachment/definitions/name"
-                },
-                "type": [
-                  "object"
-                ]
-              },
-              "config": {
-                "additionalProperties": false,
-                "description": "custom add-on provisioning options",
-                "example": {
-                  "db-version": "1.2.3"
-                },
-                "patternProperties": {
-                  "^\\w+$": {
-                    "type": [
-                      "string"
-                    ]
+                "properties": {
+                  "name": {
+                    "$ref": "#/definitions/add-on-attachment/definitions/name"
                   }
                 },
                 "type": [
                   "object"
                 ]
               },
+              "config": {
+                "$ref": "#/definitions/add-on/definitions/config"
+              },
               "confirm": {
                 "$ref": "#/definitions/add-on/definitions/confirm"
               },
               "plan": {
                 "$ref": "#/definitions/plan/definitions/identity"
+              },
+              "name": {
+                "$ref": "#/definitions/add-on/definitions/name"
               }
             },
             "required": [
@@ -1848,6 +1944,40 @@
             ]
           },
           "title": "List By Team"
+        },
+        {
+          "description": "Resolve an add-on from a name, optionally passing an app name. If there are matches it returns at least one add-on (exact match) or many.",
+          "href": "/actions/addons/resolve",
+          "method": "POST",
+          "rel": "resolve",
+          "schema": {
+            "properties": {
+              "addon": {
+                "$ref": "#/definitions/add-on/definitions/name"
+              },
+              "app": {
+                "$ref": "#/definitions/app/definitions/name"
+              },
+              "addon_service": {
+                "$ref": "#/definitions/add-on-service/definitions/name"
+              }
+            },
+            "required": [
+              "addon"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "Resolution"
         }
       ],
       "properties": {
@@ -1868,6 +1998,44 @@
           "type": [
             "object"
           ]
+        },
+        "billing_entity": {
+          "description": "billing entity associated with this add-on",
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "description": "unique identifier of the billing entity",
+              "example": "01234567-89ab-cdef-0123-456789abcdef",
+              "format": "uuid",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            },
+            "name": {
+              "description": "name of the billing entity",
+              "example": "example",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            },
+            "type": {
+              "description": "type of Object of the billing entity; new types allowed at any time.",
+              "enum": [
+                "app",
+                "team"
+              ],
+              "example": "app",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            }
+          },
+          "strictProperties": true
         },
         "app": {
           "description": "billing application associated with this add-on",
@@ -3465,7 +3633,7 @@
         "name": {
           "description": "unique name of app",
           "example": "example",
-          "pattern": "^[a-z][a-z0-9-]{2,29}$",
+          "pattern": "^[a-z][a-z0-9-]{1,28}[a-z0-9]$",
           "readOnly": false,
           "type": [
             "string"
@@ -3965,7 +4133,20 @@
             ],
             "properties": {
               "url": {
-                "$ref": "#/definitions/buildpack-installation/definitions/url"
+                "description": "the URL of the buildpack for the app",
+                "example": "https://github.com/heroku/heroku-buildpack-ruby",
+                "readOnly": false,
+                "type": [
+                  "string"
+                ]
+              },
+              "name": {
+                "description": "Buildpack Registry name of the buildpack for the app",
+                "example": "heroku/ruby",
+                "readOnly": false,
+                "type": [
+                  "string"
+                ]
               }
             }
           }
@@ -4272,7 +4453,7 @@
           ]
         },
         "name": {
-          "description": "either the shorthand name (heroku official buildpacks) or url (unofficial buildpacks) of the buildpack for the app",
+          "description": "either the Buildpack Registry name or a URL of the buildpack for the app",
           "example": "heroku/ruby",
           "readOnly": false,
           "type": [
@@ -5823,6 +6004,48 @@
           "type": [
             "string"
           ]
+        },
+        "owner": {
+          "description": "entity that owns this identity provider",
+          "properties": {
+            "id": {
+              "description": "unique identifier of the owner",
+              "example": "01234567-89ab-cdef-0123-456789abcdef",
+              "format": "uuid",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            },
+            "name": {
+              "description": "name of the owner",
+              "example": "acme",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            },
+            "type": {
+              "description": "type of the owner",
+              "enum": [
+                "team",
+                "enterprise-account"
+              ],
+              "example": "team",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            }
+          },
+          "readOnly": false,
+          "required": [
+            "id",
+            "type"
+          ],
+          "type": [
+            "object"
+          ]
         }
       },
       "links": [
@@ -6036,6 +6259,9 @@
         },
         "updated_at": {
           "$ref": "#/definitions/identity-provider/definitions/updated_at"
+        },
+        "owner": {
+          "$ref": "#/definitions/identity-provider/definitions/owner"
         }
       }
     },
@@ -9870,6 +10096,15 @@
           "items": {
             "$ref": "#/definitions/peering/definitions/cidr"
           }
+        },
+        "space_cidr_blocks": {
+          "description": "The CIDR ranges that should be routed to the Private Space VPC.",
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/peering/definitions/cidr"
+          }
         }
       },
       "links": [
@@ -9898,6 +10133,14 @@
         "aws_account_id": {
           "description": "The AWS account ID of your Private Space.",
           "example": "123456789012",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "aws_region": {
+          "description": "The AWS region of the peer connection.",
+          "example": "us-east-1",
           "readOnly": true,
           "type": [
             "string"
@@ -9987,6 +10230,9 @@
         },
         "aws_vpc_id": {
           "$ref": "#/definitions/peering/definitions/vpc_id"
+        },
+        "aws_region": {
+          "$ref": "#/definitions/peering/definitions/aws_region"
         },
         "aws_account_id": {
           "$ref": "#/definitions/peering/definitions/aws_account_id"
@@ -10170,6 +10416,21 @@
             ]
           },
           "title": "List By Pipeline"
+        },
+        {
+          "description": "List pipeline couplings for the current user.",
+          "href": "/users/~/pipeline-couplings",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/pipeline-coupling"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List For Current User"
         },
         {
           "description": "List pipeline couplings.",
@@ -12413,6 +12674,24 @@
           "type": [
             "string"
           ]
+        },
+        "cidr": {
+          "description": "The RFC-1918 CIDR the Private Space will use. It must be a /16 in 10.0.0.0/8, 172.16.0.0/12 or 192.168.0.0/16",
+          "example": "172.20.20.30/16",
+          "default": "10.0.0.0/16",
+          "pattern": "^((?:10|172\\.(?:1[6-9]|2[0-9]|3[01])|192\\.168)\\..*.+\\/16)$",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "data_cidr": {
+          "description": "The RFC-1918 CIDR that the Private Space will use for the Heroku-managed peering connection that's automatically created when using Heroku Data add-ons. It must be between a /16 and a /20",
+          "example": "10.2.0.0/16",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
         }
       },
       "links": [
@@ -12489,6 +12768,12 @@
               },
               "shield": {
                 "$ref": "#/definitions/space/definitions/shield"
+              },
+              "cidr": {
+                "$ref": "#/definitions/space/definitions/cidr"
+              },
+              "data_cidr": {
+                "$ref": "#/definitions/space/definitions/data_cidr"
               }
             },
             "required": [
@@ -12563,6 +12848,12 @@
         },
         "updated_at": {
           "$ref": "#/definitions/space/definitions/updated_at"
+        },
+        "cidr": {
+          "$ref": "#/definitions/space/definitions/cidr"
+        },
+        "data_cidr": {
+          "$ref": "#/definitions/space/definitions/data_cidr"
         }
       }
     },
@@ -12816,6 +13107,14 @@
             "string"
           ]
         },
+        "default": {
+          "description": "indicates this stack is the default for new apps",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
         "id": {
           "description": "unique identifier of stack",
           "example": "01234567-89ab-cdef-0123-456789abcdef",
@@ -12889,6 +13188,9 @@
         }
       ],
       "properties": {
+        "default": {
+          "$ref": "#/definitions/stack/definitions/default"
+        },
         "created_at": {
           "$ref": "#/definitions/stack/definitions/created_at"
         },
@@ -13045,6 +13347,15 @@
         },
         "id": {
           "$ref": "#/definitions/collaborator/definitions/id"
+        },
+        "permissions": {
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/team-app-permission"
+          },
+          "description": "array of permissions for the collaborator (only applicable if the app is on a team)"
         },
         "role": {
           "$ref": "#/definitions/team/definitions/role"
@@ -14414,6 +14725,22 @@
             }
           ]
         },
+        "device_data": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Device data string generated by the client",
+          "example": "VGhpcyBpcyBhIGdvb2QgZGF5IHRvIGRpZQ=="
+        },
+        "nonce": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Nonce generated by Braintree hosted fields form",
+          "example": "VGhpcyBpcyBhIGdvb2QgZGF5IHRvIGRpZQ=="
+        },
         "address_1": {
           "type": [
             "string"
@@ -14423,14 +14750,16 @@
         },
         "address_2": {
           "type": [
-            "string"
+            "string",
+            "null"
           ],
           "description": "street address line 2",
           "example": "Suite 103"
         },
         "card_number": {
           "type": [
-            "string"
+            "string",
+            "null"
           ],
           "description": "encrypted card number of payment method",
           "example": "encrypted-card-number"
@@ -14451,21 +14780,24 @@
         },
         "cvv": {
           "type": [
-            "string"
+            "string",
+            "null"
           ],
           "description": "card verification value",
           "example": "123"
         },
         "expiration_month": {
           "type": [
-            "string"
+            "string",
+            "null"
           ],
           "description": "expiration month",
           "example": "11"
         },
         "expiration_year": {
           "type": [
-            "string"
+            "string",
+            "null"
           ],
           "description": "expiration year",
           "example": "2014"
@@ -14486,7 +14818,8 @@
         },
         "other": {
           "type": [
-            "string"
+            "string",
+            "null"
           ],
           "description": "metadata",
           "example": "Additional information for payment method"
@@ -14662,6 +14995,12 @@
               },
               "state": {
                 "$ref": "#/definitions/team/definitions/state"
+              },
+              "nonce": {
+                "$ref": "#/definitions/team/definitions/nonce"
+              },
+              "device_data": {
+                "$ref": "#/definitions/team/definitions/device_data"
               }
             },
             "required": [
@@ -14717,6 +15056,656 @@
         },
         "updated_at": {
           "$ref": "#/definitions/team/definitions/updated_at"
+        }
+      }
+    },
+    "test-case": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "Test Case",
+      "description": "A single test case belonging to a test run",
+      "stability": "prototype",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "id": {
+          "description": "unique identifier of a test case",
+          "readOnly": true,
+          "format": "uuid",
+          "type": [
+            "string"
+          ]
+        },
+        "description": {
+          "description": "description of the test case",
+          "type": [
+            "string"
+          ]
+        },
+        "diagnostic": {
+          "description": "meta information about the test case",
+          "type": [
+            "string"
+          ]
+        },
+        "directive": {
+          "description": "special note about the test case e.g. skipped, todo",
+          "type": [
+            "string"
+          ]
+        },
+        "passed": {
+          "description": "whether the test case was successful",
+          "type": [
+            "boolean"
+          ]
+        },
+        "number": {
+          "description": "the test number",
+          "type": [
+            "integer"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/test-case/definitions/id"
+            }
+          ]
+        },
+        "created_at": {
+          "description": "when test case was created",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when test case was updated",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "List test cases",
+          "href": "/test-runs/{(%23%2Fdefinitions%2Ftest-run%2Fdefinitions%2Fid)}/test-cases",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/test-case"
+            }
+          },
+          "type": [
+            "array"
+          ],
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/test-case/definitions/id"
+        },
+        "created_at": {
+          "$ref": "#/definitions/test-case/definitions/created_at"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/test-case/definitions/updated_at"
+        },
+        "description": {
+          "$ref": "#/definitions/test-case/definitions/description"
+        },
+        "diagnostic": {
+          "$ref": "#/definitions/test-case/definitions/diagnostic"
+        },
+        "directive": {
+          "$ref": "#/definitions/test-case/definitions/directive"
+        },
+        "passed": {
+          "$ref": "#/definitions/test-case/definitions/passed"
+        },
+        "number": {
+          "$ref": "#/definitions/test-case/definitions/number"
+        },
+        "test_node": {
+          "description": "the test node which executed this test case",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/test-node/definitions/identity"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "test_run": {
+          "description": "the test run which owns this test case",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/test-run/definitions/identity"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "test-node": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "Test Node",
+      "description": "A single test node belonging to a test run",
+      "stability": "prototype",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "id": {
+          "description": "unique identifier of a test node",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "attach_url": {
+          "description": "a URL to stream output from for debug runs or null for non-debug runs",
+          "example": "rendezvous://rendezvous.runtime.heroku.com:5000/{rendezvous-id}",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "created_at": {
+          "description": "when test node was created",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "error_status": {
+          "description": "the status of the test run when the error occured",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "exit_code": {
+          "description": "the exit code of the test script",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/test-node/definitions/id"
+            }
+          ]
+        },
+        "index": {
+          "description": "The index of the test node",
+          "type": [
+            "integer"
+          ]
+        },
+        "message": {
+          "description": "human friendly message indicating reason for an error",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "output_stream_url": {
+          "description": "the streaming output for the test node",
+          "example": "https://example.com/output.log",
+          "type": [
+            "string"
+          ]
+        },
+        "setup_stream_url": {
+          "description": "the streaming test setup output for the test node",
+          "example": "https://example.com/test-setup.log",
+          "type": [
+            "string"
+          ]
+        },
+        "status": {
+          "description": "current state of the test run",
+          "enum": [
+            "pending",
+            "cancelled",
+            "creating",
+            "building",
+            "running",
+            "succeeded",
+            "failed",
+            "errored",
+            "debugging"
+          ],
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when test node was updated",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "List test nodes",
+          "href": "/test-runs/{(%23%2Fdefinitions%2Ftest-run%2Fdefinitions%2Fidentity)}/test-nodes",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/test-node"
+            }
+          },
+          "type": [
+            "array"
+          ],
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/test-node/definitions/created_at"
+        },
+        "dyno": {
+          "description": "the dyno which belongs to this test node",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/dyno/definitions/identity"
+            },
+            "attach_url": {
+              "$ref": "#/definitions/test-node/definitions/attach_url"
+            }
+          },
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "error_status": {
+          "$ref": "#/definitions/test-node/definitions/error_status"
+        },
+        "exit_code": {
+          "$ref": "#/definitions/test-node/definitions/exit_code"
+        },
+        "id": {
+          "$ref": "#/definitions/test-node/definitions/identity"
+        },
+        "index": {
+          "$ref": "#/definitions/test-node/definitions/index"
+        },
+        "message": {
+          "$ref": "#/definitions/test-node/definitions/message"
+        },
+        "output_stream_url": {
+          "$ref": "#/definitions/test-node/definitions/output_stream_url"
+        },
+        "pipeline": {
+          "description": "the pipeline which owns this test node",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/pipeline/definitions/identity"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "setup_stream_url": {
+          "$ref": "#/definitions/test-node/definitions/setup_stream_url"
+        },
+        "status": {
+          "$ref": "#/definitions/test-node/definitions/status"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/test-node/definitions/updated_at"
+        },
+        "test_run": {
+          "description": "the test run which owns this test node",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/test-run/definitions/identity"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "test-run": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "Test Run",
+      "description": "An execution or trial of one or more tests",
+      "stability": "prototype",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "actor_email": {
+          "description": "the email of the actor triggering the test run",
+          "type": [
+            "string"
+          ],
+          "format": "email"
+        },
+        "clear_cache": {
+          "description": "whether the test was run with an empty cache",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "commit_branch": {
+          "description": "the branch of the repository that the test run concerns",
+          "type": [
+            "string"
+          ]
+        },
+        "commit_message": {
+          "description": "the message for the commit under test",
+          "type": [
+            "string"
+          ]
+        },
+        "commit_sha": {
+          "description": "the SHA hash of the commit under test",
+          "type": [
+            "string"
+          ]
+        },
+        "debug": {
+          "description": "whether the test run was started for interactive debugging",
+          "type": [
+            "boolean"
+          ]
+        },
+        "app_setup": {
+          "description": "the app setup for the test run",
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of a test run",
+          "readOnly": true,
+          "format": "uuid",
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/test-run/definitions/id"
+            }
+          ]
+        },
+        "created_at": {
+          "description": "when test run was created",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "message": {
+          "description": "human friendly message indicating reason for an error",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "number": {
+          "description": "the auto incrementing test run number",
+          "type": [
+            "integer"
+          ]
+        },
+        "source_blob_url": {
+          "description": "The download location for the source code to be tested",
+          "type": [
+            "string"
+          ]
+        },
+        "status": {
+          "description": "current state of the test run",
+          "enum": [
+            "pending",
+            "cancelled",
+            "creating",
+            "building",
+            "running",
+            "succeeded",
+            "failed",
+            "errored",
+            "debugging"
+          ],
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when test-run was updated",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "warning_message": {
+          "description": "human friently warning emitted during the test run",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new test-run.",
+          "href": "/test-runs",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "commit_branch": {
+                "$ref": "#/definitions/test-run/definitions/commit_branch"
+              },
+              "commit_message": {
+                "$ref": "#/definitions/test-run/definitions/commit_message"
+              },
+              "commit_sha": {
+                "$ref": "#/definitions/test-run/definitions/commit_sha"
+              },
+              "debug": {
+                "$ref": "#/definitions/test-run/definitions/debug"
+              },
+              "organization": {
+                "$ref": "#/definitions/organization/definitions/identity"
+              },
+              "pipeline": {
+                "$ref": "#/definitions/pipeline/definitions/identity"
+              },
+              "source_blob_url": {
+                "$ref": "#/definitions/test-run/definitions/source_blob_url"
+              }
+            },
+            "required": [
+              "commit_branch",
+              "commit_message",
+              "commit_sha",
+              "pipeline",
+              "source_blob_url"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Info for existing test-run.",
+          "href": "/test-runs/{(%23%2Fdefinitions%2Ftest-run%2Fdefinitions%2Fid)}",
+          "method": "GET",
+          "rel": "self",
+          "title": "Info"
+        },
+        {
+          "description": "List existing test-runs for a pipeline.",
+          "href": "/pipelines/{(%23%2Fdefinitions%2Fpipeline%2Fdefinitions%2Fid)}/test-runs",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/test-run"
+            }
+          },
+          "type": [
+            "array"
+          ],
+          "title": "List"
+        },
+        {
+          "description": "Info for existing test-run by Pipeline",
+          "href": "/pipelines/{(%23%2Fdefinitions%2Fpipeline%2Fdefinitions%2Fid)}/test-runs/{(%23%2Fdefinitions%2Ftest-run%2Fdefinitions%2Fnumber)}",
+          "method": "GET",
+          "rel": "self",
+          "title": "Info By Pipeline"
+        },
+        {
+          "description": "Update a test-run's status.",
+          "href": "/test-runs/{(%23%2Fdefinitions%2Ftest-run%2Fdefinitions%2Fnumber)}",
+          "method": "PATCH",
+          "rel": "self",
+          "title": "Update",
+          "schema": {
+            "properties": {
+              "status": {
+                "$ref": "#/definitions/test-run/definitions/status"
+              },
+              "message": {
+                "$ref": "#/definitions/test-run/definitions/message"
+              }
+            },
+            "required": [
+              "status",
+              "message"
+            ],
+            "type": [
+              "object"
+            ]
+          }
+        }
+      ],
+      "properties": {
+        "actor_email": {
+          "$ref": "#/definitions/test-run/definitions/actor_email"
+        },
+        "clear_cache": {
+          "$ref": "#/definitions/test-run/definitions/clear_cache"
+        },
+        "commit_branch": {
+          "$ref": "#/definitions/test-run/definitions/commit_branch"
+        },
+        "commit_message": {
+          "$ref": "#/definitions/test-run/definitions/commit_message"
+        },
+        "commit_sha": {
+          "$ref": "#/definitions/test-run/definitions/commit_sha"
+        },
+        "debug": {
+          "$ref": "#/definitions/test-run/definitions/debug"
+        },
+        "app_setup": {
+          "$ref": "#/definitions/test-run/definitions/app_setup"
+        },
+        "created_at": {
+          "$ref": "#/definitions/test-run/definitions/created_at"
+        },
+        "dyno": {
+          "description": "the type of dynos used for this test-run",
+          "properties": {
+            "size": {
+              "$ref": "#/definitions/dyno/definitions/size"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "id": {
+          "$ref": "#/definitions/test-run/definitions/id"
+        },
+        "message": {
+          "$ref": "#/definitions/test-run/definitions/message"
+        },
+        "number": {
+          "$ref": "#/definitions/test-run/definitions/number"
+        },
+        "organization": {
+          "description": "the organization that owns this test-run",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/organization/definitions/name"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "pipeline": {
+          "description": "the pipeline which owns this test-run",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/pipeline/definitions/identity"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "status": {
+          "$ref": "#/definitions/test-run/definitions/status"
+        },
+        "source_blob_url": {
+          "$ref": "#/definitions/test-run/definitions/source_blob_url"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/test-run/definitions/updated_at"
+        },
+        "user": {
+          "$ref": "#/definitions/account"
+        },
+        "warning_message": {
+          "$ref": "#/definitions/test-run/definitions/warning_message"
         }
       }
     },
@@ -14939,7 +15928,7 @@
     "vpn-connection": {
       "description": "[VPN](https://devcenter.heroku.com/articles/private-spaces-vpn?preview=1) provides a way to connect your Private Spaces to your network via VPN.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "stability": "prototype",
+      "stability": "production",
       "strictProperties": true,
       "title": "Heroku Platform API - Private Spaces VPN",
       "type": [
@@ -15068,7 +16057,6 @@
             "provisioning",
             "active",
             "deprovisioning",
-            "complete",
             "failed"
           ],
           "example": "active",
@@ -15638,6 +16626,15 @@
     },
     "team": {
       "$ref": "#/definitions/team"
+    },
+    "test-case": {
+      "$ref": "#/definitions/test-case"
+    },
+    "test-node": {
+      "$ref": "#/definitions/test-node"
+    },
+    "test-run": {
+      "$ref": "#/definitions/test-run"
     },
     "user-preferences": {
       "$ref": "#/definitions/user-preferences"


### PR DESCRIPTION
NOTE: while working on this, I noticed an issue with the way we reference buildpacks, this may break. I'd like reviewers thoughts on how to change this (a buildpack sub resource, checking if the value is a URL)
(I made a change this in my other PR, but was ruminating as I was pulling those changes here and I see issues potentially with people mixing Buildpack Registry names and URLs for custom buildpacks, so the resource may need to change to support them separately)

Break out the `heroku-go` vendor update from #167
