### PR TITLE
Make source tarball in a temporary location

### DIFF
--- a/heroku/resource_heroku_build_test.go
+++ b/heroku/resource_heroku_build_test.go
@@ -184,6 +184,27 @@ func TestAccHerokuBuild_LocalSourceDirectory(t *testing.T) {
 	})
 }
 
+// https://github.com/terraform-providers/terraform-provider-heroku/issues/160
+func TestAccHerokuBuild_LocalSourceDirectorySelfContained(t *testing.T) {
+	var build heroku.Build
+	defer func() { _ = resetSourceDirectories() }()
+
+	// cd to the ./test-fixtures/app directory before and revert back afterwards
+	_ = os.Chdir("./test-fixtures/app")
+	defer func() { _ = os.Chdir("../..") }()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuBuildConfig_localSourceDirectorySelfContained(fmt.Sprintf("tftest-%s", acctest.RandString(10))),
+				Check:  testAccCheckHerokuBuildExists("heroku_build.foobar", &build),
+			},
+		},
+	})
+}
+
 func testAccCheckHerokuBuildExists(n string, Build *heroku.Build) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -289,6 +310,19 @@ resource "heroku_build" "foobar" {
     app = "${heroku_app.foobar.name}"
     source = {
       path = "test-fixtures/app/"
+    }
+}`, appName)
+}
+
+func testAccCheckHerokuBuildConfig_localSourceDirectorySelfContained(appName string) string {
+	return fmt.Sprintf(`resource "heroku_app" "foobar" {
+    name = "%s"
+    region = "us"
+}
+ resource "heroku_build" "foobar" {
+    app = "${heroku_app.foobar.name}"
+    source = {
+      path = "."
     }
 }`, appName)
 }


### PR DESCRIPTION
Currently the provider makes the source tarball in the current directory
If your terraform code is in a subdirectory of the application you will
get an error making a source tarball with source = { path = ".." }.

This delegates creation of the temporary tarball to ioutil.TempFile and
removes the need to for go-uuid.

Fixes #160 