### PR TITLE
New data resource: Heroku Team

### DIFF
--- a/helper/test/config.go
+++ b/helper/test/config.go
@@ -19,6 +19,7 @@ const (
 	TestConfigSpaceOrganizationKey
 	TestConfigSlugIDKey
 	TestConfigEmail
+	TestConfigTeam
 )
 
 var testConfigKeyToEnvName = map[TestConfigKey]string{
@@ -29,6 +30,7 @@ var testConfigKeyToEnvName = map[TestConfigKey]string{
 	TestConfigSpaceOrganizationKey: "HEROKU_SPACES_ORGANIZATION",
 	TestConfigSlugIDKey:            "HEROKU_SLUG_ID",
 	TestConfigEmail:                "HEROKU_EMAIL",
+	TestConfigTeam:                 "HEROKU_TEAM",
 	TestConfigAcceptanceTestKey:    resource.TestEnvVar,
 }
 
@@ -118,4 +120,8 @@ func (t *TestConfig) GetUserOrSkip(testing *testing.T) (val string) {
 
 func (t *TestConfig) GetEmailOrSkip(testing *testing.T) (val string) {
 	return t.GetOrSkip(testing, TestConfigEmail)
+}
+
+func (t *TestConfig) GetTeamOrSkip(testing *testing.T) (val string) {
+	return t.GetOrSkip(testing, TestConfigTeam)
 }

--- a/heroku/data_source_heroku_team.go
+++ b/heroku/data_source_heroku_team.go
@@ -1,0 +1,60 @@
+package heroku
+
+import (
+	"context"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceHerokuTeam() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceHerokuTeamRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"default": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"membership_limit": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"provisioned_licenses": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceHerokuTeamRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(*Config).Api
+
+	name := d.Get("name").(string)
+
+	team, err := client.TeamInfo(context.TODO(), name)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(team.ID)
+
+	var setErr error
+	setErr = d.Set("name", team.Name)
+	setErr = d.Set("default", team.Default)
+	setErr = d.Set("membership_limit", team.MembershipLimit)
+	setErr = d.Set("provisioned_licenses", team.ProvisionedLicenses)
+	setErr = d.Set("type", team.Type)
+
+	return setErr
+}

--- a/heroku/data_source_heroku_team_test.go
+++ b/heroku/data_source_heroku_team_test.go
@@ -1,0 +1,36 @@
+package heroku
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/resource"
+	"testing"
+)
+
+func TestAccDatasourceHerokuTeam_Basic(t *testing.T) {
+	// Since there will not be a heroku_team resource, this test will require an existing team for execution.
+	teamName := testAccConfig.GetTeamOrSkip(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuTeamWithDataSource_Basic(teamName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.heroku_team.foobar", "name", teamName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckHerokuTeamWithDataSource_Basic(teamName string) string {
+	return fmt.Sprintf(`
+
+data "heroku_team" "foobar" {
+  name = "%s"
+}
+`, teamName)
+}

--- a/heroku/provider.go
+++ b/heroku/provider.go
@@ -92,6 +92,7 @@ func Provider() terraform.ResourceProvider {
 			"heroku_app":                dataSourceHerokuApp(),
 			"heroku_space":              dataSourceHerokuSpace(),
 			"heroku_space_peering_info": dataSourceHerokuSpacePeeringInfo(),
+			"heroku_team":               dataSourceHerokuTeam(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/website/docs/d/team.html.markdown
+++ b/website/docs/d/team.html.markdown
@@ -1,0 +1,45 @@
+---
+layout: "heroku"
+page_title: "Heroku: heroku_team"
+sidebar_current: "docs-heroku-datasource-team-x"
+description: |-
+  Get information on a Heroku Team.
+---
+
+# Data Source: heroku_team
+
+Use this data source to get information about a Heroku Team or Heroku Enterprise team.
+
+## Example Usage
+
+```hcl
+data "heroku_team" "my_heroku_team" {
+  name = "name_of_my_heroku_team"
+}
+
+output "heroku_team_data_basic" {
+  value = [
+    "Heroku team",
+    "id: ${data.heroku_team.my_heroku_team.id}",
+    "default: ${data.heroku_team.my_heroku_team.default}",
+    "membership_limit: ${data.heroku_team.my_heroku_team.membership_limit}",
+    "provisioned_licenses: ${data.heroku_team.my_heroku_team.provisioned_licenses}",
+    "type: ${data.heroku_team.my_heroku_team.type}",
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `name` - (Required) The team name
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the team
+* `default` - Whether to use this team when none is specified
+* `credit_card_collections` - Whether charges incurred by the team are paid by credit card
+* `membership_limit` - Upper limit of members allowed in a team
+* `provisioned_licenses` - Whether the team is provisioned licenses by Salesforce
+* `type` - type of team Will likely be either "enterprise" or "team"

--- a/website/heroku.erb
+++ b/website/heroku.erb
@@ -25,6 +25,9 @@
                     <li<%= sidebar_current("docs-heroku-datasource-space-peering-info") %>>
           <a href="/docs/providers/heroku/d/space_peering_info.html">heroku_space_peering_info</a>
                     </li>
+                  <li<%= sidebar_current("docs-heroku-datasource-team") %>>
+                    <a href="/docs/providers/heroku/d/team.html">heroku_team</a>
+                  </li>
                 </ul>
 
         <li<%= sidebar_current("docs-heroku-resource") %>>


### PR DESCRIPTION
New data source for heroku teams and heroku enterprise teams:

```
data "heroku_team" "my_heroku_team" {
  name = "name_of_my_heroku_team"
}
```

Sample output in state:
```
                "data.heroku_team.my_heroku_team": {
                    "type": "heroku_team",
                    "depends_on": [],
                    "primary": {
                        "id": "<some_uuid>",
                        "attributes": {
                            "default": "false",
                            "id": "<some_uuid>",
                            "membership_limit": "500",
                            "name": "<some_team>",
                            "provisioned_licenses": "true"
                        },
                        "meta": {},
                        "tainted": false
                    },
                    "deposed": [],
                    "provider": "provider.heroku"
                },
```