### PR TITLE
Fix Unhandled Errors

### DIFF
--- a/heroku/data_source_heroku_app.go
+++ b/heroku/data_source_heroku_app.go
@@ -115,7 +115,10 @@ func dataSourceHerokuAppRead(d *schema.ResourceData, m interface{}) error {
 		}
 	}
 
-	setAppDetails(d, app)
+	setErr := setAppDetails(d, app)
+	if setErr != nil {
+		return setErr
+	}
 
 	d.Set("buildpacks", app.Buildpacks)
 	d.Set("config_vars", app.Vars)

--- a/heroku/provider_test.go
+++ b/heroku/provider_test.go
@@ -51,7 +51,10 @@ func TestProviderConfigureUsesHeadersForClient(t *testing.T) {
 			t.Errorf("got X-Custom-Header: %q, want `yes`", got)
 		}
 
-		w.Write([]byte(`{"name":"some-app"}`))
+		_, writeErr := w.Write([]byte(`{"name":"some-app"}`))
+		if writeErr != nil {
+			t.Fatal(writeErr)
+		}
 	}))
 	defer srv.Close()
 
@@ -104,7 +107,11 @@ func createTempConfigFile(content string, name string) (*os.File, error) {
 
 	_, err = tmpfile.WriteString(content)
 	if err != nil {
-		os.Remove(tmpfile.Name())
+		removeErr := os.Remove(tmpfile.Name())
+		if removeErr != nil {
+			return nil, removeErr
+		}
+
 		return nil, fmt.Errorf("Error writing to temporary test file. err: %s", err.Error())
 	}
 

--- a/heroku/resource_heroku_account_feature.go
+++ b/heroku/resource_heroku_account_feature.go
@@ -53,7 +53,10 @@ func resourceHerokuAccountFeatureImport(d *schema.ResourceData, meta interface{}
 	d.SetId(d.Id())
 	d.Set("name", accountFeatureName)
 
-	resourceHerokuAccountFeatureRead(d, meta)
+	readErr := resourceHerokuAccountFeatureRead(d, meta)
+	if readErr != nil {
+		return nil, readErr
+	}
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/heroku/resource_heroku_app_feature.go
+++ b/heroku/resource_heroku_app_feature.go
@@ -42,7 +42,10 @@ func resourceHerokuAppFeature() *schema.Resource {
 }
 
 func resourceHerokuAppFeatureImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	resourceHerokuAppFeatureRead(d, meta)
+	readErr := resourceHerokuAppFeatureRead(d, meta)
+	if readErr != nil {
+		return nil, readErr
+	}
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/heroku/resource_heroku_build_test.go
+++ b/heroku/resource_heroku_build_test.go
@@ -397,29 +397,39 @@ func testAccCheckSourceChecksumIsDifferent(buildName string, originalSourceCheck
 }
 
 func switchSourceDirectories() (bool, error) {
-	os.Rename("test-fixtures/app", "test-fixtures/app-orig")
-	os.Rename("test-fixtures/app-2", "test-fixtures/app")
-	return false, nil
+	var renameErr error
+	renameErr = os.Rename("test-fixtures/app", "test-fixtures/app-orig")
+	renameErr = os.Rename("test-fixtures/app-2", "test-fixtures/app")
+	return false, renameErr
 }
 
 func resetSourceDirectories() error {
 	if _, err := os.Stat("test-fixtures/app-orig"); err == nil {
-		os.Rename("test-fixtures/app", "test-fixtures/app-2")
-		os.Rename("test-fixtures/app-orig", "test-fixtures/app")
+		var renameErr error
+		renameErr = os.Rename("test-fixtures/app", "test-fixtures/app-2")
+		renameErr = os.Rename("test-fixtures/app-orig", "test-fixtures/app")
+		if renameErr != nil {
+			return renameErr
+		}
 	}
 	return nil
 }
 
 func switchSourceFiles() (bool, error) {
-	os.Rename("test-fixtures/app.tgz", "test-fixtures/app-orig.tgz")
-	os.Rename("test-fixtures/app-2.tgz", "test-fixtures/app.tgz")
-	return false, nil
+	var renameErr error
+	renameErr = os.Rename("test-fixtures/app.tgz", "test-fixtures/app-orig.tgz")
+	renameErr = os.Rename("test-fixtures/app-2.tgz", "test-fixtures/app.tgz")
+	return false, renameErr
 }
 
 func resetSourceFiles() error {
 	if _, err := os.Stat("test-fixtures/app-orig.tgz"); err == nil {
-		os.Rename("test-fixtures/app.tgz", "test-fixtures/app-2.tgz")
-		os.Rename("test-fixtures/app-orig.tgz", "test-fixtures/app.tgz")
+		var renameErr error
+		renameErr = os.Rename("test-fixtures/app.tgz", "test-fixtures/app-2.tgz")
+		renameErr = os.Rename("test-fixtures/app-orig.tgz", "test-fixtures/app.tgz")
+		if renameErr != nil {
+			return renameErr
+		}
 	}
 	return nil
 }

--- a/heroku/resource_heroku_cert.go
+++ b/heroku/resource_heroku_cert.go
@@ -65,7 +65,10 @@ func resourceHerokuCertImport(d *schema.ResourceData, meta interface{}) ([]*sche
 	}
 
 	d.SetId(ep.ID)
-	d.Set("app", app)
+	setErr := d.Set("app", app)
+	if setErr != nil {
+		return nil, setErr
+	}
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/heroku/resource_heroku_slug_test.go
+++ b/heroku/resource_heroku_slug_test.go
@@ -323,15 +323,20 @@ resource "heroku_slug" "foobar" {
 }
 
 func switchSlugFiles() (bool, error) {
-	os.Rename("test-fixtures/slug.tgz", "test-fixtures/slug-orig.tgz")
-	os.Rename("test-fixtures/slug-2.tgz", "test-fixtures/slug.tgz")
-	return false, nil
+	var err error
+	err = os.Rename("test-fixtures/slug.tgz", "test-fixtures/slug-orig.tgz")
+	err = os.Rename("test-fixtures/slug-2.tgz", "test-fixtures/slug.tgz")
+	return false, err
 }
 
 func resetSlugFiles() error {
 	if _, err := os.Stat("test-fixtures/slug-orig.tgz"); err == nil {
-		os.Rename("test-fixtures/slug.tgz", "test-fixtures/slug-2.tgz")
-		os.Rename("test-fixtures/slug-orig.tgz", "test-fixtures/slug.tgz")
+		var err error
+		err = os.Rename("test-fixtures/slug.tgz", "test-fixtures/slug-2.tgz")
+		err = os.Rename("test-fixtures/slug-orig.tgz", "test-fixtures/slug.tgz")
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/heroku/resource_heroku_space_app_access.go
+++ b/heroku/resource_heroku_space_app_access.go
@@ -50,7 +50,10 @@ func resourceHerokuSpaceAppAccessImport(d *schema.ResourceData, meta interface{}
 	}
 	d.Set("space", space)
 	d.Set("email", email)
-	resourceHerokuSpaceAppAccessRead(d, meta)
+	readErr := resourceHerokuSpaceAppAccessRead(d, meta)
+	if readErr != nil {
+		return nil, readErr
+	}
 	return []*schema.ResourceData{d}, nil
 }
 

--- a/heroku/resource_heroku_team_member.go
+++ b/heroku/resource_heroku_team_member.go
@@ -54,7 +54,11 @@ func resourceHerokuTeamMemberImport(d *schema.ResourceData, meta interface{}) ([
 	}
 	d.Set("team", team)
 	d.Set("email", email)
-	resourceHerokuTeamMemberRead(d, meta)
+
+	readErr := resourceHerokuTeamMemberRead(d, meta)
+	if readErr != nil {
+		return nil, readErr
+	}
 	return []*schema.ResourceData{d}, nil
 }
 


### PR DESCRIPTION
I noticed several areas in the code base where we have unhandled errors, especially around setting state attributes. This PR will aim to handle all those errors.

Using this (https://github.com/kisielk/errcheck)[handy library], I generated the following:

```
heroku/data_source_heroku_addon.go:58:7:	d.Set("name", addon.Name)
heroku/data_source_heroku_addon.go:59:7:	d.Set("app", addon.App.Name)
heroku/data_source_heroku_addon.go:60:7:	d.Set("plan", addon.Plan.Name)
heroku/data_source_heroku_addon.go:61:7:	d.Set("provider_id", addon.ProviderID)
heroku/data_source_heroku_addon.go:62:7:	d.Set("config_vars", addon.ConfigVars)
heroku/data_source_heroku_app.go:118:15:	setAppDetails(d, app)
heroku/data_source_heroku_app.go:120:7:	d.Set("buildpacks", app.Buildpacks)
heroku/data_source_heroku_app.go:121:7:	d.Set("config_vars", app.Vars)
heroku/data_source_heroku_space.go:83:7:	d.Set("state", space.State)
heroku/data_source_heroku_space.go:84:7:	d.Set("shield", space.Shield)
heroku/data_source_heroku_space_peering_info.go:68:7:	d.Set("aws_account_id", peeringInfo.AwsAccountID)
heroku/data_source_heroku_space_peering_info.go:69:7:	d.Set("aws_region", peeringInfo.AwsRegion)
heroku/data_source_heroku_space_peering_info.go:70:7:	d.Set("vpc_id", peeringInfo.VpcID)
heroku/data_source_heroku_space_peering_info.go:71:7:	d.Set("vpc_cidr", peeringInfo.VpcCIDR)
heroku/data_source_heroku_space_peering_info.go:72:7:	d.Set("dyno_cidr_blocks", peeringInfo.DynoCIDRBlocks)
heroku/data_source_heroku_space_peering_info.go:73:7:	d.Set("unavailable_cidr_blocks", peeringInfo.UnavailableCIDRBlocks)
heroku/provider_test.go:42:7:	d.Set("headers", `{"X-Custom-Header":"yes"}`)
heroku/provider_test.go:54:10:	w.Write([]byte(`{"name":"some-app"}`))
heroku/provider_test.go:107:12:	os.Remove(tmpfile.Name())
heroku/resource_heroku_account_feature.go:54:7:	d.Set("name", accountFeatureName)
heroku/resource_heroku_account_feature.go:56:34:	resourceHerokuAccountFeatureRead(d, meta)
heroku/resource_heroku_account_feature.go:96:7:	d.Set("name", accountFeature.Name)
heroku/resource_heroku_account_feature.go:97:7:	d.Set("description", accountFeature.Description)
heroku/resource_heroku_account_feature.go:98:7:	d.Set("state", accountFeature.State)
heroku/resource_heroku_account_feature.go:99:7:	d.Set("enabled", accountFeature.Enabled)
heroku/resource_heroku_addon.go:149:7:	d.Set("name", addon.Name)
heroku/resource_heroku_addon.go:150:7:	d.Set("app", addon.App.Name)
heroku/resource_heroku_addon.go:151:7:	d.Set("plan", plan)
heroku/resource_heroku_addon.go:152:7:	d.Set("provider_id", addon.ProviderID)
heroku/resource_heroku_addon_attachment.go:83:7:	d.Set("app_id", addonattachment.App.Name)
heroku/resource_heroku_addon_attachment.go:84:7:	d.Set("addon_id", addonattachment.Addon.ID)
heroku/resource_heroku_addon_attachment.go:85:7:	d.Set("name", addonattachment.Name)
heroku/resource_heroku_app_feature.go:45:30:	resourceHerokuAppFeatureRead(d, meta)
heroku/resource_heroku_app_feature.go:63:7:	d.Set("app", app)
heroku/resource_heroku_app_feature.go:64:7:	d.Set("name", feature.Name)
heroku/resource_heroku_app_feature.go:65:7:	d.Set("enabled", feature.Enabled)
heroku/resource_heroku_app_release.go:104:7:	d.Set("app", appRelease.App.Name)
heroku/resource_heroku_app_release.go:105:7:	d.Set("slug_id", appRelease.Slug.ID)
heroku/resource_heroku_app_release.go:106:7:	d.Set("description", appRelease.Description)
heroku/resource_heroku_app_release.go:153:7:	d.Set("app", appRelease.App.Name)
heroku/resource_heroku_app_release.go:154:7:	d.Set("slug_id", appRelease.Slug.ID)
heroku/resource_heroku_app_release.go:155:7:	d.Set("description", appRelease.Description)
heroku/resource_heroku_build.go:156:15:	setBuildState(d, build, app)
heroku/resource_heroku_build.go:269:15:	setBuildState(d, build, app)
heroku/resource_heroku_build.go:285:15:	setBuildState(d, build, app)
heroku/resource_heroku_build.go:352:18:	defer file.Close()
heroku/resource_heroku_build.go:372:22:	defer res.Body.Close()
heroku/resource_heroku_build.go:389:12:	file.Close()
heroku/resource_heroku_build.go:398:7:	d.Set("app", appName)
heroku/resource_heroku_build.go:409:7:	d.Set("output_stream_url", build.OutputStreamURL)
heroku/resource_heroku_build.go:412:8:	d.Set("release_id", build.Release.ID)
heroku/resource_heroku_build.go:416:8:	d.Set("slug_id", build.Slug.ID)
heroku/resource_heroku_build.go:431:9:	d.Set("local_checksum", build.SourceBlob.Checksum)
heroku/resource_heroku_build.go:441:7:	d.Set("stack", build.Stack)
heroku/resource_heroku_build.go:442:7:	d.Set("status", build.Status)
heroku/resource_heroku_build.go:452:7:	d.Set("uuid", build.ID)
heroku/resource_heroku_build_test.go:96:24:	defer resetSourceFiles()
heroku/resource_heroku_build_test.go:162:30:	defer resetSourceDirectories()
heroku/resource_heroku_build_test.go:400:11:	os.Rename("test-fixtures/app", "test-fixtures/app-orig")
heroku/resource_heroku_build_test.go:401:11:	os.Rename("test-fixtures/app-2", "test-fixtures/app")
heroku/resource_heroku_build_test.go:407:12:	os.Rename("test-fixtures/app", "test-fixtures/app-2")
heroku/resource_heroku_build_test.go:408:12:	os.Rename("test-fixtures/app-orig", "test-fixtures/app")
heroku/resource_heroku_build_test.go:414:11:	os.Rename("test-fixtures/app.tgz", "test-fixtures/app-orig.tgz")
heroku/resource_heroku_build_test.go:415:11:	os.Rename("test-fixtures/app-2.tgz", "test-fixtures/app.tgz")
heroku/resource_heroku_build_test.go:421:12:	os.Rename("test-fixtures/app.tgz", "test-fixtures/app-2.tgz")
heroku/resource_heroku_build_test.go:422:12:	os.Rename("test-fixtures/app-orig.tgz", "test-fixtures/app.tgz")
heroku/resource_heroku_cert.go:107:7:	d.Set("certificate_chain", cert.CertificateChain)
heroku/resource_heroku_cert.go:108:7:	d.Set("name", cert.Name)
heroku/resource_heroku_cert.go:109:7:	d.Set("cname", cert.CName)
heroku/resource_heroku_domain.go:58:7:	d.Set("app", app)
heroku/resource_heroku_domain.go:77:7:	d.Set("hostname", do.Hostname)
heroku/resource_heroku_domain.go:78:7:	d.Set("cname", do.CName)
heroku/resource_heroku_domain.go:109:7:	d.Set("hostname", do.Hostname)
heroku/resource_heroku_domain.go:110:7:	d.Set("cname", do.CName)
heroku/resource_heroku_drain.go:62:7:	d.Set("app", app)
heroku/resource_heroku_drain.go:92:7:	d.Set("url", dr.URL)
heroku/resource_heroku_drain.go:93:7:	d.Set("token", dr.Token)
heroku/resource_heroku_drain.go:121:7:	d.Set("url", dr.URL)
heroku/resource_heroku_drain.go:122:7:	d.Set("token", dr.Token)
heroku/resource_heroku_formation.go:229:7:	d.Set("app", formation.App.Name)
heroku/resource_heroku_formation.go:230:7:	d.Set("type", formation.Type)
heroku/resource_heroku_formation.go:231:7:	d.Set("quantity", formation.Quantity)
heroku/resource_heroku_formation.go:232:7:	d.Set("size", formation.Size)
heroku/resource_heroku_pipeline.go:40:7:	d.Set("name", p.Name)
heroku/resource_heroku_pipeline.go:60:7:	d.Set("name", p.Name)
heroku/resource_heroku_pipeline.go:106:7:	d.Set("name", p.Name)
heroku/resource_heroku_pipeline_coupling.go:101:8:	d.Set("app", app.Name)
heroku/resource_heroku_pipeline_coupling.go:104:7:	d.Set("app_id", p.App.ID)
heroku/resource_heroku_pipeline_coupling.go:105:7:	d.Set("stage", p.Stage)
heroku/resource_heroku_pipeline_coupling.go:106:7:	d.Set("pipeline", p.Pipeline.ID)
heroku/resource_heroku_slug.go:142:7:	d.Set("app", app)
heroku/resource_heroku_slug.go:143:14:	setSlugState(d, slug)
heroku/resource_heroku_slug.go:241:14:	setSlugState(d, slug)
heroku/resource_heroku_slug.go:256:14:	setSlugState(d, slug)
heroku/resource_heroku_slug.go:309:22:	defer res.Body.Close()
heroku/resource_heroku_slug.go:318:22:	defer slugFile.Close()
heroku/resource_heroku_slug.go:319:9:	io.Copy(slugFile, res.Body)
heroku/resource_heroku_slug.go:336:18:	defer file.Close()
heroku/resource_heroku_slug.go:356:22:	defer res.Body.Close()
heroku/resource_heroku_slug.go:372:12:	file.Close()
heroku/resource_heroku_slug.go:388:7:	d.Set("buildpack_provided_description", slug.BuildpackProvidedDescription)
heroku/resource_heroku_slug.go:389:7:	d.Set("checksum", slug.Checksum)
heroku/resource_heroku_slug.go:390:7:	d.Set("commit", slug.Commit)
heroku/resource_heroku_slug.go:391:7:	d.Set("commit_description", slug.CommitDescription)
heroku/resource_heroku_slug.go:396:7:	d.Set("size", slug.Size)
heroku/resource_heroku_slug.go:397:7:	d.Set("stack_id", slug.Stack.ID)
heroku/resource_heroku_slug.go:398:7:	d.Set("stack", slug.Stack.Name)
heroku/resource_heroku_slug_test.go:79:22:	defer resetSlugFiles()
heroku/resource_heroku_slug_test.go:326:11:	os.Rename("test-fixtures/slug.tgz", "test-fixtures/slug-orig.tgz")
heroku/resource_heroku_slug_test.go:327:11:	os.Rename("test-fixtures/slug-2.tgz", "test-fixtures/slug.tgz")
heroku/resource_heroku_slug_test.go:333:12:	os.Rename("test-fixtures/slug.tgz", "test-fixtures/slug-2.tgz")
heroku/resource_heroku_slug_test.go:334:12:	os.Rename("test-fixtures/slug-orig.tgz", "test-fixtures/slug.tgz")
heroku/resource_heroku_space.go:185:7:	d.Set("name", space.Name)
heroku/resource_heroku_space.go:186:7:	d.Set("organization", space.Organization.Name)
heroku/resource_heroku_space.go:187:7:	d.Set("region", space.Region.Name)
heroku/resource_heroku_space.go:188:7:	d.Set("trusted_ip_ranges", space.TrustedIPRanges)
heroku/resource_heroku_space.go:189:7:	d.Set("outbound_ips", space.NAT.Sources)
heroku/resource_heroku_space.go:190:7:	d.Set("shield", space.Shield)
heroku/resource_heroku_space.go:191:7:	d.Set("cidr", space.CIDR)
heroku/resource_heroku_space.go:192:7:	d.Set("data_cidr", space.DataCIDR)
heroku/resource_heroku_space.go:234:8:	d.Set("trusted_ip_ranges", ranges)
heroku/resource_heroku_space_app_access.go:51:7:	d.Set("space", space)
heroku/resource_heroku_space_app_access.go:52:7:	d.Set("email", email)
heroku/resource_heroku_space_app_access.go:53:34:	resourceHerokuSpaceAppAccessRead(d, meta)
heroku/resource_heroku_space_app_access.go:76:7:	d.Set("space", spaceAppAccess.Space.Name)
heroku/resource_heroku_space_app_access.go:77:7:	d.Set("email", spaceAppAccess.User.Email)
heroku/resource_heroku_space_app_access.go:78:7:	d.Set("permissions", createPermissionsList(spaceAppAccess))
heroku/resource_heroku_space_inbound_ruleset.go:103:7:	d.Set("rule", rulesList)
heroku/resource_heroku_space_inbound_ruleset.go:104:7:	d.Set("space", ruleset.Space.Name)
heroku/resource_heroku_space_peering_connection_accepter.go:98:7:	d.Set("status", p.Status)
heroku/resource_heroku_space_peering_connection_accepter.go:99:7:	d.Set("type", p.Type)
heroku/resource_heroku_space_peering_connection_accepter.go:115:7:	d.Set("status", peeringConn.Status)
heroku/resource_heroku_space_peering_connection_accepter.go:116:7:	d.Set("type", peeringConn.Type)
heroku/resource_heroku_space_peering_connection_accepter.go:117:7:	d.Set("vpc_peering_connection_id", peeringConn.PcxID)
heroku/resource_heroku_space_vpn_connection.go:97:7:	d.Set("space", space)
heroku/resource_heroku_space_vpn_connection.go:98:7:	d.Set("name", conn.Name)
heroku/resource_heroku_space_vpn_connection.go:99:7:	d.Set("public_ip", conn.PublicIP)
heroku/resource_heroku_space_vpn_connection.go:100:7:	d.Set("routable_cidrs", conn.RoutableCidrs)
heroku/resource_heroku_space_vpn_connection.go:101:7:	d.Set("space_cidr_block", conn.SpaceCIDRBlock)
heroku/resource_heroku_space_vpn_connection.go:102:7:	d.Set("ike_version", conn.IKEVersion)
heroku/resource_heroku_space_vpn_connection.go:111:7:	d.Set("tunnels", tunnels)
heroku/resource_heroku_team_collaborator.go:129:7:	d.Set("app", teamCollaborator.AppName)
heroku/resource_heroku_team_collaborator.go:130:7:	d.Set("email", teamCollaborator.TeamCollaborator.Email)
heroku/resource_heroku_team_collaborator.go:131:7:	d.Set("permissions", teamCollaborator.Permissions)
heroku/resource_heroku_team_collaborator.go:280:7:	d.Set("app", collaborator.App.Name)
heroku/resource_heroku_team_collaborator.go:281:7:	d.Set("email", collaborator.User.Email)
heroku/resource_heroku_team_collaborator.go:282:7:	d.Set("permissions", collaborator.Permissions)
heroku/resource_heroku_team_member.go:55:7:	d.Set("team", team)
heroku/resource_heroku_team_member.go:56:7:	d.Set("email", email)
heroku/resource_heroku_team_member.go:57:30:	resourceHerokuTeamMemberRead(d, meta)
heroku/resource_heroku_team_member.go:110:7:	d.Set("team", team)
heroku/resource_heroku_team_member.go:111:7:	d.Set("email", found.Email)
heroku/resource_heroku_team_member.go:112:7:	d.Set("role", found.Role)
heroku/resource_heroku_team_member.go:113:7:	d.Set("federated", found.Federated)
```