### PR TITLE
Ability to set addon name

### DIFF
--- a/heroku/resource_heroku_addon.go
+++ b/heroku/resource_heroku_addon.go
@@ -187,10 +187,10 @@ func resourceHerokuAddonUpdate(d *schema.ResourceData, meta interface{}) error {
 		opts.Plan = d.Get("plan").(string)
 	}
 
-	// TODO: uncomment once the go client supports this
-	//if d.HasChange("name") {
-	//	opts.Name = d.Get("name").(string)
-	//}
+	if d.HasChange("name") {
+		n := d.Get("name").(string)
+		opts.Name = &n
+	}
 
 	ad, updateErr := client.AddOnUpdate(context.TODO(), app, d.Id(), opts)
 	if updateErr != nil {

--- a/heroku/resource_heroku_addon_test.go
+++ b/heroku/resource_heroku_addon_test.go
@@ -111,7 +111,41 @@ func TestAccHerokuAddon_CustomName_Invalid(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccCheckHerokuAddonConfig_CustomName(appName, customName),
-				ExpectError: regexp.MustCompile(`Invalid custom addon name:.*`),
+				ExpectError: regexp.MustCompile(`config is invalid: invalid value for name`),
+			},
+		},
+	})
+}
+
+func TestAccHerokuAddon_CustomName_EmptyString(t *testing.T) {
+	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	customName := ""
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHerokuAddonDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckHerokuAddonConfig_CustomName(appName, customName),
+				ExpectError: regexp.MustCompile(`config is invalid: 2 problems:.*`),
+			},
+		},
+	})
+}
+
+func TestAccHerokuAddon_CustomName_FirstCharNum(t *testing.T) {
+	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	customName := "1dasdad"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHerokuAddonDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckHerokuAddonConfig_CustomName(appName, customName),
+				ExpectError: regexp.MustCompile(`config is invalid: invalid value for name`),
 			},
 		},
 	})

--- a/heroku/resource_heroku_addon_test.go
+++ b/heroku/resource_heroku_addon_test.go
@@ -76,7 +76,7 @@ func TestAccHerokuAddon_noPlan(t *testing.T) {
 func TestAccHerokuAddon_CustomName(t *testing.T) {
 	var addon heroku.AddOn
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
-	customName := fmt.Sprintf("tftest-%s", acctest.RandString(15))
+	customName := fmt.Sprintf("custom-addonname-%s", acctest.RandString(15))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/website/docs/r/addon.html.markdown
+++ b/website/docs/r/addon.html.markdown
@@ -43,6 +43,7 @@ The following arguments are supported:
 * `app` - (Required) The Heroku app to add to.
 * `plan` - (Required) The addon to add.
 * `config` - (Optional) Optional plan configuration.
+* `name` - (Optional) Globally unique name of the add-on.
 
 ## Attributes Reference
 


### PR DESCRIPTION
- Need to update `heroku-go` to support passing in `Name` during a `PATCH` addon request.

Related to #209.