### PR TITLE
Change config from block to attribute assignment

### DIFF
--- a/website/docs/r/addon.html.markdown
+++ b/website/docs/r/addon.html.markdown
@@ -30,7 +30,7 @@ resource "heroku_addon" "webhook" {
   app  = "${heroku_app.default.name}"
   plan = "deployhooks:http"
 
-  config {
+  config = {
     url = "http://google.com"
   }
 }


### PR DESCRIPTION
Terraform 0.12.x requires config to be an attribute for me, not a block.