### PR TITLE
Add ability to manage App Webhooks

### DIFF
--- a/heroku/import_heroku_app_webhook_test.go
+++ b/heroku/import_heroku_app_webhook_test.go
@@ -1,0 +1,30 @@
+package heroku
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccHerokuAppWebhook_importBasic(t *testing.T) {
+	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuAppWebhookConfig(appName, "https://terraform.example.com:4321", "sync", "api:build"),
+			},
+			{
+				ResourceName:        "heroku_app_webhook.foobar_webhook",
+				ImportStateIdPrefix: appName + ":",
+				ImportState:         true,
+			},
+		},
+	})
+}

--- a/heroku/provider.go
+++ b/heroku/provider.go
@@ -71,6 +71,7 @@ func Provider() terraform.ResourceProvider {
 			"heroku_app_config_association":            resourceHerokuAppConfigAssociation(),
 			"heroku_app_feature":                       resourceHerokuAppFeature(),
 			"heroku_app_release":                       resourceHerokuAppRelease(),
+			"heroku_app_webhook":                       resourceHerokuAppWebhook(),
 			"heroku_build":                             resourceHerokuBuild(),
 			"heroku_cert":                              resourceHerokuCert(),
 			"heroku_config":                            resourceHerokuConfig(),

--- a/heroku/resource_heroku_app_webhook.go
+++ b/heroku/resource_heroku_app_webhook.go
@@ -1,0 +1,236 @@
+package heroku
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	validation "github.com/hashicorp/terraform/helper/validation"
+	heroku "github.com/heroku/heroku-go/v5"
+)
+
+func resourceHerokuAppWebhook() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceHerokuAppWebhookCreate,
+		Read:   resourceHerokuAppWebhookRead,
+		Update: resourceHerokuAppWebhookUpdate,
+		Delete: resourceHerokuAppWebhookDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: resourceHerokuAppWebhookImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"app_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"level": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice([]string{"notify", "sync"}, true),
+			},
+
+			"url": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"include": &schema.Schema{
+				Type:     schema.TypeList,
+				Required: true,
+				MinItems: 1,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{
+						"api:addon-attachment",
+						"api:addon",
+						"api:app",
+						"api:build",
+						"api:collaborator",
+						"api:domain",
+						"api:dyno",
+						"api:formation",
+						"api:release",
+						"api:sni-endpoint",
+						"api:ssl-endpoint"}, true),
+				},
+			},
+
+			"secret": &schema.Schema{
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			},
+
+			"authorization": &schema.Schema{
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+// Callback for schema Resource.Create
+func resourceHerokuAppWebhookCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Config).Api
+
+	appId := getAppId(d)
+
+	opts := heroku.AppWebhookCreateOpts{
+		Level:   d.Get("level").(string),
+		URL:     d.Get("url").(string),
+		Include: getInclude(d),
+	}
+
+	if v, ok := d.GetOk("secret"); ok {
+		secret := v.(string)
+		opts.Secret = &secret
+	}
+
+	if v, ok := d.GetOk("authorization"); ok {
+		authorization := v.(string)
+		opts.Authorization = &authorization
+	}
+
+	webhook, err := client.AppWebhookCreate(context.TODO(), appId, opts)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(webhook.ID)
+
+	return nil
+}
+
+// Callback for schema Resource.Read
+func resourceHerokuAppWebhookRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Config).Api
+
+	appId := getAppId(d)
+
+	webhook, err := client.AppWebhookInfo(context.TODO(), appId, d.Id())
+	if err != nil {
+		return err
+	}
+
+	d.Set("url", webhook.URL)
+	d.Set("level", webhook.Level)
+	d.Set("include", webhook.Include)
+
+	return nil
+}
+
+// Callback for schema Resource.Update
+func resourceHerokuAppWebhookUpdate(d *schema.ResourceData, meta interface{}) error {
+	// Enable Partial state mode and what we successfully committed
+	d.Partial(true)
+
+	client := meta.(*Config).Api
+	opts := heroku.AppWebhookUpdateOpts{}
+
+	appId := getAppId(d)
+
+	if d.HasChange("level") {
+		v := d.Get("level").(string)
+		log.Printf("[DEBUG] New Level: %s", v)
+		opts.Level = &v
+	}
+
+	if d.HasChange("url") {
+		v := d.Get("url").(string)
+		log.Printf("[DEBUG] New URL: %v", v)
+		opts.URL = &v
+	}
+
+	if d.HasChange("include") {
+		v := getIncludeAsPointers(d)
+		log.Printf("[DEBUG] New include: %v", v)
+		opts.Include = v
+	}
+
+	if d.HasChange("secret") {
+		if v, ok := d.GetOk("secret"); ok {
+			secret := v.(string)
+			log.Printf("[DEBUG] New Secret: %s", secret)
+			opts.Secret = &secret
+		} else {
+			log.Printf("[DEBUG] Secret Removed")
+			opts.Secret = nil
+		}
+	}
+
+	if d.HasChange("authorization") {
+		if v, ok := d.GetOk("authorization"); ok {
+			authorization := v.(string)
+			log.Printf("[DEBUG] New Authorization: %s", authorization)
+			opts.Authorization = &authorization
+		} else {
+			log.Printf("[DEBUG] Authorization Removed")
+			opts.Authorization = nil
+		}
+	}
+
+	log.Printf("[DEBUG] Updating Heroku webhook...")
+	_, err := client.AppWebhookUpdate(context.TODO(), appId, d.Id(), opts)
+
+	if err != nil {
+		return err
+	}
+
+	d.Partial(false)
+
+	return nil
+}
+
+// Callback for schema Resource.Delete
+func resourceHerokuAppWebhookDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Config).Api
+	appId := getAppId(d)
+
+	_, err := client.AppWebhookDelete(context.TODO(), appId, d.Id())
+	return err
+}
+
+func resourceHerokuAppWebhookImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client := meta.(*Config).Api
+
+	app, id, err := parseCompositeID(d.Id())
+
+	webhook, err := client.AppWebhookInfo(context.TODO(), app, id)
+	if err != nil {
+		return nil, err
+	}
+
+	d.SetId(webhook.ID)
+	d.Set("app_id", webhook.App.ID)
+	d.Set("url", webhook.URL)
+	d.Set("level", webhook.Level)
+	d.Set("include", webhook.Include)
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func getInclude(d *schema.ResourceData) []string {
+	rawInclude := d.Get("include").([]interface{})
+	include := make([]string, len(rawInclude))
+
+	for i, v := range rawInclude {
+		include[i] = v.(string)
+	}
+	return include
+}
+
+func getIncludeAsPointers(d *schema.ResourceData) []*string {
+	rawInclude := d.Get("include").([]interface{})
+	include := make([]*string, len(rawInclude))
+
+	for i, v := range rawInclude {
+		vv := v.(string)
+		include[i] = &vv
+	}
+	return include
+}

--- a/heroku/resource_heroku_app_webhook_test.go
+++ b/heroku/resource_heroku_app_webhook_test.go
@@ -1,0 +1,126 @@
+package heroku
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	heroku "github.com/heroku/heroku-go/v5"
+)
+
+func TestAccHerokuAppWebhook_Basic(t *testing.T) {
+	var webhook heroku.AppWebhookInfoResult
+	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHerokuAppWebhookDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuAppWebhookConfig(appName, "https://terraform.example.com:1234", "notify", "api:release"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHerokuAppWebhookExists("heroku_app_webhook.foobar_webhook", &webhook),
+					testAccCheckHerokuAppWebhookAttributes(&webhook, "https://terraform.example.com:1234", "notify", "api:release"),
+					resource.TestCheckResourceAttr("heroku_app_webhook.foobar_webhook", "url", "https://terraform.example.com:1234"),
+					resource.TestCheckResourceAttr("heroku_app_webhook.foobar_webhook", "level", "notify"),
+					resource.TestCheckResourceAttr("heroku_app_webhook.foobar_webhook", "include.0", "api:release"),
+				),
+			},
+			{
+				Config: testAccCheckHerokuAppWebhookConfig(appName, "https://terraform.example.com:4321", "sync", "api:build"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHerokuAppWebhookExists("heroku_app_webhook.foobar_webhook", &webhook),
+					testAccCheckHerokuAppWebhookAttributes(&webhook, "https://terraform.example.com:4321", "sync", "api:build"),
+					resource.TestCheckResourceAttr("heroku_app_webhook.foobar_webhook", "url", "https://terraform.example.com:4321"),
+					resource.TestCheckResourceAttr("heroku_app_webhook.foobar_webhook", "level", "sync"),
+					resource.TestCheckResourceAttr("heroku_app_webhook.foobar_webhook", "include.0", "api:build"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckHerokuAppWebhookConfig(appName, url, level, include string) string {
+	return fmt.Sprintf(`
+resource "heroku_app" "foobar" {
+    name = "%s"
+    region = "us"
+}
+
+resource "heroku_app_webhook" "foobar_webhook" {
+    app_id  = "${heroku_app.foobar.id}"
+    url     = "%s"
+    level   = "%s"
+    include = ["%s"]
+}`, appName, url, level, include)
+}
+
+func testAccCheckHerokuAppWebhookDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*Config).Api
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "heroku_app_webhook" {
+			continue
+		}
+
+		_, err := client.AppWebhookInfo(context.TODO(), rs.Primary.Attributes["app"], rs.Primary.ID)
+
+		if err == nil {
+			return fmt.Errorf("Webhook still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckHerokuAppWebhookExists(n string, Webhook *heroku.AppWebhookInfoResult) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Webhook ID is set")
+		}
+
+		client := testAccProvider.Meta().(*Config).Api
+
+		foundWebhook, err := client.AppWebhookInfo(context.TODO(), rs.Primary.Attributes["app_id"], rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if foundWebhook.ID != rs.Primary.ID {
+			return fmt.Errorf("Webhook not found")
+		}
+
+		*Webhook = *foundWebhook
+
+		return nil
+	}
+}
+
+func testAccCheckHerokuAppWebhookAttributes(Webhook *heroku.AppWebhookInfoResult, url, level, include string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if Webhook.URL != url {
+			return fmt.Errorf("Bad URL: %s", Webhook.URL)
+		}
+
+		if Webhook.Level != level {
+			return fmt.Errorf("Bad Level: %s", Webhook.Level)
+		}
+
+		if len(Webhook.Include) != 1 || Webhook.Include[0] != include {
+			return fmt.Errorf("Bad Include: %v", Webhook.Include)
+		}
+
+		return nil
+	}
+}

--- a/website/docs/r/app_webhook.html.markdown
+++ b/website/docs/r/app_webhook.html.markdown
@@ -1,0 +1,47 @@
+---
+layout: "heroku"
+page_title: "Heroku: heroku_app_webhook"
+sidebar_current: "docs-heroku-resource-app-webhook"
+description: |-
+  Provides the ability to manage application webhooks
+---
+
+# heroku\_app\_webhook
+
+Provides a [Heroku App Webhook](https://devcenter.heroku.com/categories/app-webhooks).
+
+## Example Usage
+
+```hcl
+# Create a new Heroku app
+resource "heroku_app" "foobar" {
+  name = "foobar"
+}
+
+# Add a web-hook for the app
+resource "heroku_app_webhook" "foobar_release" {
+  app_id  = "${heroku_app.foobar.id}"
+  level   = "notify"
+  url     = "https://example.com/heroku_webhook"
+  include = ["api:release"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `app_id` - (Required) The Heroku app to add to.
+* `level` - (Required) The webhook level (either `notify` or `sync`)
+* `url` - (Required) Optional plan configuration.
+* `include` - (Required) List of events to deliver to the webhook.
+* `secret` - (Optional) Value used to sign webhook payloads. Once set, this value cannot be fetched from the Heroku API, but it can be updated.
+* `authorization` - (Optional) Values used in `Authorization` header. Once set, this value cannot be fetched from the Heroku API, but it can be updated.
+
+## Importing
+
+Existing webhooks can be imported using the combination of the application name or id, a colon, and the webhook name or id, e.g.
+
+```
+$ terraform import heroku_app_webhook.foobar_release foobar:b85d9224-310b-409b-891e-c903f5a40568
+```

--- a/website/heroku.erb
+++ b/website/heroku.erb
@@ -61,6 +61,10 @@
                       <a href="/docs/providers/heroku/r/app_release.html">heroku_app_release</a>
                     </li>
 
+                    <li<%= sidebar_current("docs-heroku-resource-app-webhook") %>>
+                      <a href="/docs/providers/heroku/r/app_webhook.html">heroku_app_webhook</a>
+                    </li>
+
                     <li<%= sidebar_current("docs-heroku-resource-build") %>>
                       <a href="/docs/providers/heroku/r/build.html">heroku_build</a>
                     </li>


### PR DESCRIPTION
Adds the ability to manage [Heroku App Webhooks](https://devcenter.heroku.com/categories/app-webhooks) as terraform resources.

There are still some less basic test cases to cover, however we would appreciate reviews nonetheless 😃.

It is worth mentioning that the management of the `secret` + `authorization` is a bit awkward, as there is no way to unset them.