### PR TITLE
Various bug fixes for `heroku_app` resource

### DIFF
--- a/heroku/data_source_heroku_app.go
+++ b/heroku/data_source_heroku_app.go
@@ -107,7 +107,7 @@ func dataSourceHerokuAppRead(d *schema.ResourceData, m interface{}) error {
 	d.SetId(app.App.ID)
 
 	if app.IsTeamApp {
-		setErr := setOrganizationDetails(d, app)
+		setErr := setTeamDetails(d, app)
 		if setErr != nil {
 			return setErr
 		}

--- a/heroku/data_source_heroku_app.go
+++ b/heroku/data_source_heroku_app.go
@@ -99,17 +99,17 @@ func dataSourceHerokuAppRead(d *schema.ResourceData, m interface{}) error {
 	client := m.(*Config).Api
 
 	name := d.Get("name").(string)
-	app, err := resourceHerokuAppRetrieve(name, true, client)
+	app, err := resourceHerokuAppRetrieve(name, client)
 	if err != nil {
 		return err
 	}
 
 	d.SetId(app.App.ID)
 
-	if app.Organization {
-		err := setOrganizationDetails(d, app)
-		if err != nil {
-			return err
+	if app.IsTeamApp {
+		setErr := setOrganizationDetails(d, app)
+		if setErr != nil {
+			return setErr
 		}
 	}
 

--- a/heroku/import_heroku_app_test.go
+++ b/heroku/import_heroku_app_test.go
@@ -21,10 +21,12 @@ func TestAccHerokuApp_importBasic(t *testing.T) {
 				Config: testAccCheckHerokuAppConfig_basic(appName, appStack),
 			},
 			{
-				ResourceName:            "heroku_app.foobar",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"config_vars"},
+				ResourceName:      "heroku_app.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+
+				// Due to the nature of these two attributes, it will not be possible to import them as part of the resource import.
+				ImportStateVerifyIgnore: []string{"config_vars", "sensitive_config_vars"},
 			},
 		},
 	})
@@ -45,10 +47,12 @@ func TestAccHerokuApp_importOrganization(t *testing.T) {
 				Config: testAccCheckHerokuAppConfig_organization(appName, org),
 			},
 			{
-				ResourceName:            "heroku_app.foobar",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"config_vars"},
+				ResourceName:      "heroku_app.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+
+				// Due to the nature of these two attributes, it will not be possible to import them as part of the resource import.
+				ImportStateVerifyIgnore: []string{"config_vars", "sensitive_config_vars"},
 			},
 		},
 	})

--- a/heroku/import_heroku_app_test.go
+++ b/heroku/import_heroku_app_test.go
@@ -57,3 +57,28 @@ func TestAccHerokuApp_importOrganization(t *testing.T) {
 		},
 	})
 }
+
+func TestAccHerokuApp_importBuildpacks(t *testing.T) {
+	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHerokuAppDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuAppConfig_multi(appName),
+			},
+			{
+				ResourceName:      "heroku_app.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+
+				// Due to the nature of these two attributes, it will not be possible to import them as part of the resource import.
+				ImportStateVerifyIgnore: []string{"config_vars", "sensitive_config_vars"},
+			},
+		},
+	})
+}

--- a/heroku/resource_heroku_app.go
+++ b/heroku/resource_heroku_app.go
@@ -145,12 +145,6 @@ func resourceHerokuApp() *schema.Resource {
 				Computed: true,
 			},
 
-			"uuid": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-
 			"internal_routing": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -417,7 +411,6 @@ func setAppDetails(d *schema.ResourceData, app *application) (err error) {
 	err = d.Set("git_url", app.App.GitURL)
 	err = d.Set("web_url", app.App.WebURL)
 	err = d.Set("acm", app.App.Acm)
-	err = d.Set("uuid", app.App.ID)
 	err = d.Set("heroku_hostname", fmt.Sprintf("%s.herokuapp.com", app.App.Name))
 
 	return err

--- a/heroku/resource_heroku_app.go
+++ b/heroku/resource_heroku_app.go
@@ -252,7 +252,7 @@ func resourceHerokuAppImport(d *schema.ResourceData, m interface{}) ([]*schema.R
 	// EDIT: (March 21, 2020) - The statement above causes issues for child resources
 	// of heroku_app such as heroku_addon where the `app` attribute is often set to ForceNew.
 	// As the app's name can change, its UUID does not. Therefore the heroku_app.id should have originally
-	// be set to the UUID to prevent unnecessary destroy and recreates of child resources. - DJ
+	// be set to the UUID to prevent unnecessary destroy and recreates of child app resources. - DJ
 	d.SetId(app.ID)
 
 	readErr := resourceHerokuAppRead(d, m)

--- a/heroku/resource_heroku_app.go
+++ b/heroku/resource_heroku_app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"log"
 	"net/url"
 	"time"
@@ -149,8 +150,9 @@ func resourceHerokuApp() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
 						},
 
 						"locked": {

--- a/heroku/resource_heroku_app_test.go
+++ b/heroku/resource_heroku_app_test.go
@@ -612,7 +612,7 @@ func testAccCheckHerokuAppExists(n string, app *heroku.App) resource.TestCheckFu
 			return err
 		}
 
-		if foundApp.Name != rs.Primary.ID {
+		if foundApp.ID != rs.Primary.ID {
 			return fmt.Errorf("App not found")
 		}
 
@@ -642,7 +642,7 @@ func testAccCheckHerokuAppExistsOrg(n string, app *heroku.TeamApp) resource.Test
 			return err
 		}
 
-		if foundApp.Name != rs.Primary.ID {
+		if foundApp.ID != rs.Primary.ID {
 			return fmt.Errorf("App not found")
 		}
 

--- a/heroku/resource_heroku_app_test.go
+++ b/heroku/resource_heroku_app_test.go
@@ -204,7 +204,6 @@ func TestAccHerokuApp_ExternallySetBuildpacks(t *testing.T) {
 				Config:    testAccCheckHerokuAppConfig_no_vars(appName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAppExists("heroku_app.foobar", &app),
-					testAccCheckHerokuAppBuildpacks(appName, false),
 					resource.TestCheckNoResourceAttr("heroku_app.foobar", "buildpacks.0"),
 				),
 			},
@@ -541,7 +540,7 @@ func testAccCheckHerokuAppBuildpacks(appName string, multi bool) resource.TestCh
 		}
 
 		if len(buildpacks) != 1 || buildpacks[0] != "heroku/go" {
-			return fmt.Errorf("bad buildpacks: %v", buildpacks)
+			return fmt.Errorf("expected buildpack length to not equal 1 OR buildpacks[0] to not be \"heroku/go\" but got: %v", buildpacks)
 		}
 
 		return nil
@@ -563,7 +562,7 @@ func testAccCheckHerokuAppNoBuildpacks(appName string) resource.TestCheckFunc {
 		}
 
 		if len(buildpacks) != 0 {
-			return fmt.Errorf("bad buildpacks: %v", buildpacks)
+			return fmt.Errorf("expected 0 buildpacks but got %d: %v", len(buildpacks), buildpacks)
 		}
 
 		return nil

--- a/heroku/resource_heroku_app_test.go
+++ b/heroku/resource_heroku_app_test.go
@@ -3,6 +3,7 @@ package heroku
 import (
 	"context"
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -521,22 +522,26 @@ func testAccCheckHerokuAppBuildpacks(appName string, multi bool) resource.TestCh
 			return err
 		}
 
-		buildpacks := []string{}
+		log.Printf("[DEBUG] List of the app's buildpack installations: %v", results)
+
+		buildpacks := make([]string, 0)
 		for _, installation := range results {
 			buildpacks = append(buildpacks, installation.Buildpack.Name)
 		}
 
+		log.Printf("[DEBUG] List of the buildpacks: %v", buildpacks)
+
 		if multi {
 			herokuMulti := "https://github.com/heroku/heroku-buildpack-multi-procfile"
 			if len(buildpacks) != 2 || buildpacks[0] != herokuMulti || buildpacks[1] != "heroku/go" {
-				return fmt.Errorf("Bad buildpacks: %v", buildpacks)
+				return fmt.Errorf("bad buildpacks: %v", buildpacks)
 			}
 
 			return nil
 		}
 
 		if len(buildpacks) != 1 || buildpacks[0] != "heroku/go" {
-			return fmt.Errorf("Bad buildpacks: %v", buildpacks)
+			return fmt.Errorf("bad buildpacks: %v", buildpacks)
 		}
 
 		return nil
@@ -552,13 +557,13 @@ func testAccCheckHerokuAppNoBuildpacks(appName string) resource.TestCheckFunc {
 			return err
 		}
 
-		buildpacks := []string{}
+		buildpacks := make([]string, 0)
 		for _, installation := range results {
 			buildpacks = append(buildpacks, installation.Buildpack.Name)
 		}
 
 		if len(buildpacks) != 0 {
-			return fmt.Errorf("Bad buildpacks: %v", buildpacks)
+			return fmt.Errorf("bad buildpacks: %v", buildpacks)
 		}
 
 		return nil
@@ -759,6 +764,8 @@ func testAccCheckHerokuAppConfig_no_vars(appName string) string {
 resource "heroku_app" "foobar" {
   name   = "%s"
   region = "us"
+
+  buildpacks = []
 
   config_vars = {}
 }`, appName)

--- a/heroku/resource_heroku_app_test.go
+++ b/heroku/resource_heroku_app_test.go
@@ -636,7 +636,7 @@ func testAccCheckHerokuAppExists(n string, app *heroku.App) resource.TestCheckFu
 			return err
 		}
 
-		if foundApp.ID != rs.Primary.ID {
+		if foundApp.Name != rs.Primary.ID {
 			return fmt.Errorf("App not found")
 		}
 
@@ -666,7 +666,7 @@ func testAccCheckHerokuAppExistsOrg(n string, app *heroku.TeamApp) resource.Test
 			return err
 		}
 
-		if foundApp.ID != rs.Primary.ID {
+		if foundApp.Name != rs.Primary.ID {
 			return fmt.Errorf("App not found")
 		}
 

--- a/heroku/resource_heroku_formation_test.go
+++ b/heroku/resource_heroku_formation_test.go
@@ -52,7 +52,7 @@ func TestAccHerokuFormationUpdateFreeDyno(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuFormationConfig_WithOrg("", appName, slugID, "free", 1),
+				Config: testAccCheckHerokuFormationConfig_WithOutOrg(appName, slugID, "free", 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuFormationExists("heroku_formation.foobar-web", &formation),
 					testAccCheckHerokuFormationSizeAttribute(&formation, "Free"),
@@ -128,4 +128,23 @@ resource "heroku_formation" "foobar-web" {
 	quantity = %d
 }
 `, appName, org, slugId, dynoSize, dynoQuant)
+}
+
+func testAccCheckHerokuFormationConfig_WithOutOrg(appName, slugId, dynoSize string, dynoQuant int) string {
+	return fmt.Sprintf(`
+resource "heroku_app" "foobar" {
+    name = "%s"
+    region = "us"
+}
+resource "heroku_app_release" "foobar-release" {
+	app = "${heroku_app.foobar.name}"
+	slug_id = "%s"
+}
+resource "heroku_formation" "foobar-web" {
+	app = "${heroku_app.foobar.name}"
+	type = "web"
+	size = "%s"
+	quantity = %d
+}
+`, appName, slugId, dynoSize, dynoQuant)
 }

--- a/website/docs/r/app.html.markdown
+++ b/website/docs/r/app.html.markdown
@@ -95,9 +95,8 @@ config vars to `heroku_app_config_association` resource.
 
 The following attributes are exported:
 
-* `id` - The ID of the app. This is also the name of the application.
-* `name` - The name of the application. In Heroku, this is also the
-   unique ID.
+* `id` - The ID of the app. This is the UUID of the app. **NOTE:** Use this for `null_resource` triggers.
+* `name` - The name of the application.
 * `stack` - The application stack is what platform to run the application
    in.
 * `space` - The private space the app should run in.
@@ -114,12 +113,13 @@ The following attributes are exported:
     exist for the app, containing both those set by Terraform and those
     set externally. (These are treated as "sensitive" so that
     their values are redacted in console output.)
-* `uuid` - The unique UUID of the Heroku app. **NOTE:** Use this for `null_resource` triggers.
 
 ## Import
 
-Apps can be imported using the App `id`, e.g.
+Apps can be imported using an existing app's `UUID` or name.
 
+For example:
 ```
 $ terraform import heroku_app.foobar MyApp
+$ terraform import heroku_app.foobar e74ac056-7d00-4a7e-aa80-df4bc413a825
 ```

--- a/website/docs/r/app.html.markdown
+++ b/website/docs/r/app.html.markdown
@@ -93,7 +93,7 @@ config vars to `heroku_app_config_association` resource.
 
 The following attributes are exported:
 
-* `id` - The ID of the app. This is the UUID of the app. **NOTE:** Use this for `null_resource` triggers.
+* `id` - The ID of the app. This is also the name of the app.
 * `name` - The name of the application.
 * `stack` - The application stack is what platform to run the application
    in.
@@ -111,6 +111,7 @@ The following attributes are exported:
     exist for the app, containing both those set by Terraform and those
     set externally. (These are treated as "sensitive" so that
     their values are redacted in console output.)
+* `uuid` - The unique UUID of the Heroku app. **NOTE:** Use this for `null_resource` triggers.
 
 ## Import
 

--- a/website/docs/r/app.html.markdown
+++ b/website/docs/r/app.html.markdown
@@ -8,8 +8,7 @@ description: |-
 
 # heroku\_app
 
-Provides a Heroku App resource. This can be used to
-create and manage applications on Heroku.
+Provides a Heroku App resource. This can be used to create and manage applications on Heroku.
 
 ## Example Usage
 
@@ -30,8 +29,7 @@ resource "heroku_app" "default" {
 
 ## Example Usage for a Team
 
-A Heroku "team" was originally called an "organization", and that is still 
-the identifier used in this resource.
+A Heroku "team" was originally called an "organization", and that is still the identifier used in this resource.
 
 ```hcl
 resource "heroku_app" "default" {


### PR DESCRIPTION
Resolves #249
Resolves #118 

----

1) While looking into #249, it didn't seem `heroku_app`'s import function set ALL of the attributes of the app. So I changed this function to use the same read function as when creating/updating a `heroku_app`.

2) (EDIT: THIS change was undone) I also found it a good opportunity to change the value of `heroku_app.id` from the app's name to its UUID. We should always be prioritizing and using the resource's UUID whenever possible as the name is not idempotent. This shouldn't cause any major for users other than needing to reference the `heroku_app.name` instead of `heroku_app.id` for a child resource such as `heroku_addon.app_id` to avoid a destroy and recreate. Example state:
```
  ID = 89e3fff4-29c9-4362-ad21-2e5edcba1e74
  provider = provider.heroku
  acm = false
  git_url = https://git.heroku.com/<SOME_APP_NAME>.git
  heroku_hostname = <SOME_APP_NAME>.herokuapp.com
  internal_routing = false
  name = <SOME_APP_NAME>
  organization.# = 1
  organization.0.locked = true
  organization.0.name = <SOME_ORG_NAME>
  organization.0.personal = false
  region = us
  space =
  stack = heroku-18
  web_url = https://<SOME_APP_NAME>.herokuapp.com/
```

3) Fix #118. I don't see how the `lock` attribute wouldn't be respected in a `heroku_app` creation but nevertheless, I fixed how this attribute is set in state.

4) I removed `heroku_app.uuid`. It should never have been an optional attribute and also redundant since `heroku_app.id` is now set to its UUID.

5) I did some basic refactoring in the `heroku_app` resource code.