### PR TITLE
Fix random VPN create failures

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -9,7 +9,6 @@ build: fmtcheck
 	go install
 
 test: fmtcheck
-	go test -i $(TEST) || exit 1
 	echo $(TEST) | \
 		xargs -t -n4 go test -v $(TESTARGS) -timeout=30s -parallel=4
 

--- a/heroku/resource_heroku_space_vpn_connection.go
+++ b/heroku/resource_heroku_space_vpn_connection.go
@@ -156,6 +156,9 @@ func resourceHerokuSpaceVPNConnectionCreate(d *schema.ResourceData, meta interfa
 
 		return resource.NonRetryableError(nil)
 	})
+	if err != nil {
+		return fmt.Errorf("Error waiting for VPN to become available: %v", err)
+	}
 
 	d.SetId(buildCompositeID(space, id))
 

--- a/heroku/resource_heroku_space_vpn_connection.go
+++ b/heroku/resource_heroku_space_vpn_connection.go
@@ -137,27 +137,27 @@ func resourceHerokuSpaceVPNConnectionCreate(d *schema.ResourceData, meta interfa
 	id := conn.ID
 
 	log.Printf("[DEBUG] Waiting for VPN (%s) to be allocated", id)
-	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-		conn, err := client.VPNConnectionInfo(context.TODO(), space, id)
+	retryErr := resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		vpn, vpnGetErr := client.VPNConnectionInfo(context.TODO(), space, id)
 
 		// Retry on "not found"
-		if err != nil && strings.Contains(err.Error(), "VPN is not found") {
+		if vpnGetErr != nil && strings.Contains(vpnGetErr.Error(), "VPN is not found") {
 			return resource.RetryableError(fmt.Errorf("Waiting for new VPN connection"))
 		}
 
 		// Fail for any remaining error
-		if err != nil {
-			return resource.NonRetryableError(fmt.Errorf("Error fetching VPN connection status: %s", err))
+		if vpnGetErr != nil {
+			return resource.NonRetryableError(fmt.Errorf("Error fetching VPN connection status: %s", vpnGetErr))
 		}
 
-		if conn.Status != "active" {
-			return resource.RetryableError(fmt.Errorf("Want VPN connection status 'active', instead got '%s'", conn.Status))
+		if vpn.Status != "active" {
+			return resource.RetryableError(fmt.Errorf("Want VPN connection status 'active', instead got '%s'", vpn.Status))
 		}
 
 		return resource.NonRetryableError(nil)
 	})
-	if err != nil {
-		return fmt.Errorf("Error waiting for VPN to become available: %v", err)
+	if retryErr != nil {
+		return fmt.Errorf("Error waiting for VPN to become available: %v", retryErr)
 	}
 
 	d.SetId(buildCompositeID(space, id))


### PR DESCRIPTION
This test has been flappy for years. Let's fix it!

Ends-up, it's an issue with the VPN connection create process. Issuing the `POST` to create the VPN connection, and then immediately `GET` to retrieve status, results in occasional, seemingly random **not found** errors. This seems to be the same eventually-consistent behavior we observe with other resources of the Heroku Platform API.

Therefore, this changeset makes the VPN connection create method retry-await on **not found** as well as not-`active` statuses, until it eventually becomes `active`.