### PR TITLE
[doc] Remove `name` from heroku_config example

### DIFF
--- a/website/docs/r/app_config_association.html.markdown
+++ b/website/docs/r/app_config_association.html.markdown
@@ -30,8 +30,6 @@ different values on both resources at the same time. It is recommended to use on
 ## Example HCL
 ```hcl
 resource "heroku_config" "common" {
-    name = "common-vars"
-
     vars = {
         LOG_LEVEL = "info"
     }


### PR DESCRIPTION
```
Error: Unsupported argument

  on main.tf line 10, in resource "heroku_config" "common":
  10:     name = "common-vars"

An argument named "name" is not expected here.
```