### PR TITLE
Upgrade acceptance tests to Go 1.14

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -16,10 +16,10 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-    - name: Install Go 1.13
+    - name: Install Go 1.14
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.14
       id: go
 
     - uses: actions/checkout@master

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Requirements
 ------------
 
 - [Terraform](https://www.terraform.io/downloads.html) 0.12.x
-- [Go](https://golang.org/doc/install) 1.13 (to build the provider plugin)
+- [Go](https://golang.org/doc/install) 1.14 (to build the provider plugin)
 
 Usage
 -----


### PR DESCRIPTION
This updates the GH action for acceptance tests to Go1.14.